### PR TITLE
Properly bubble up exceptions that are thrown by the parsing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ MyParsingClass {
 ## Future Enhancements
 
 - Generate code so that member variables only need to be package local
+- Add an option to absorb parsing errors rather than re-throwing them
 
 ## License
 `stag-java` is available under the MIT license. See the [LICENSE](LICENSE) file for more information.

--- a/sample/src/main/java/com/vimeo/sample/model/DateParser.java
+++ b/sample/src/main/java/com/vimeo/sample/model/DateParser.java
@@ -48,8 +48,7 @@ public class DateParser extends TypeAdapter<Date> {
         try {
             return dateFormat.parse(in.nextString());
         } catch (ParseException e) {
-            e.printStackTrace();
+            throw new IOException("Date parsing failed", e);
         }
-        return null;
     }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/ParseGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/ParseGenerator.java
@@ -253,9 +253,9 @@ public class ParseGenerator {
                                      "\t\t\t\ttry {\n" +
                                      "\t\t\t\t\tobject." + variableName + " = " +
                                      getReadType(element.getValue()) +
-                                     "\n\t\t\t\t} catch(Exception e) {" +
+                                     "\n\t\t\t\t} catch(Exception exception) {" +
                                      "\n\t\t\t\t\tthrow new IOException(\"Error parsing " +
-                                     info.getClassName() + "." + variableName + " JSON!\");" +
+                                     info.getClassName() + "." + variableName + " JSON!\", exception);" +
                                      "\n\t\t\t\t}" +
                                      '\n' +
                                      "\t\t\t\tbreak;\n");


### PR DESCRIPTION
#### Ticket
[VA-1894](https://vimean.atlassian.net/browse/VA-1894)

#### Ticket Summary
Due to some buggy json we are pulling down from the server, we are getting a crash in the android app. We want to pinpoint the exact part of the object that isn't able to be parsed.

#### Implementation Summary
We should be bubbling up exceptions in our parsing code so that the consumer can track down the precise location of the parsing failure.

#### How to Test
See the sample app, modify one of the fields that isn't a Date in a model class to a Date and of course it will fail with a parse exception. Now we will bubble up the origin instead of just catching an error
