### PR TITLE
use google auto service

### DIFF
--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     compile 'com.squareup:javapoet:1.7.0'
     compile 'com.intellij:annotations:12.0@jar'
     compile 'com.google.auto.service:auto-service:1.0-rc2'
-    compile 'com.google.auto:auto-common:0.6'
 }
 
 test {

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.squareup:javapoet:1.7.0'
     compile 'com.intellij:annotations:12.0@jar'
+    compile 'com.google.auto.service:auto-service:1.0-rc2'
+    compile 'com.google.auto:auto-common:0.6'
 }
 
 test {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -23,6 +23,7 @@
  */
 package com.vimeo.stag.processor;
 
+import com.google.auto.service.AutoService;
 import com.vimeo.stag.GsonAdapterKey;
 import com.vimeo.stag.processor.generators.ParseGenerator;
 import com.vimeo.stag.processor.generators.StagGenerator;
@@ -44,6 +45,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
@@ -54,6 +56,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
+@AutoService(Processor.class)
 @SupportedAnnotationTypes("com.vimeo.stag.GsonAdapterKey")
 @SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class StagProcessor extends AbstractProcessor {

--- a/stag-library-compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/stag-library-compiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-com.vimeo.stag.processor.StagProcessor


### PR DESCRIPTION
#### Ticket

#### Ticket Summary
use google auto service 

#### Implementation Summary
add google auto service to generate META-INF metadata for Java
annotation processors automatically

#### How to Test
sync the gradle and stag-java-compiler generate the same source java file.
