### PR TITLE
Release preparation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ allprojects {
 
 subprojects {
     group = 'com.vimeo.stag'
-    version = '1.0.1'
+    version = '1.1.0'
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -144,11 +144,13 @@ public final class StagProcessor extends AbstractProcessor {
                 if (TypeUtils.isConcreteType(element)) {
                     ClassInfo classInfo = new ClassInfo(element.asType());
                     TypeAdapterGenerator independentAdapter = new TypeAdapterGenerator(classInfo);
-                    JavaFile javaFile = JavaFile.builder(classInfo.getPackageName(), independentAdapter.getTypeAdapterSpec()).build();
+                    JavaFile javaFile = JavaFile.builder(classInfo.getPackageName(),
+                                                         independentAdapter.getTypeAdapterSpec()).build();
                     FileGenUtils.writeToFile(javaFile, filer);
 
                     TypeAdapterFactoryGenerator factoryGenerator = new TypeAdapterFactoryGenerator(classInfo);
-                    javaFile = JavaFile.builder(classInfo.getPackageName(), factoryGenerator.getTypeAdapterFactorySpec()).build();
+                    javaFile = JavaFile.builder(classInfo.getPackageName(),
+                                                factoryGenerator.getTypeAdapterFactorySpec()).build();
                     FileGenUtils.writeToFile(javaFile, filer);
                 }
             }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -52,14 +52,14 @@ import javax.lang.model.type.TypeMirror;
 
 public class StagGenerator {
 
-    public static final String CLASS_STAG = "Stag";
+    private static final String CLASS_STAG = "Stag";
     private static final String CLASS_TYPE_ADAPTER_FACTORY = "Factory";
 
     @NotNull
     private final Filer mFiler;
 
     @NotNull
-    private Set<String> mKnownTypeAdapterFactories = new HashSet<>();
+    private final Set<String> mKnownTypeAdapterFactories = new HashSet<>();
 
     public StagGenerator(@NotNull Filer filer, @NotNull Set<String> knownTypes) {
         mFiler = filer;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -128,14 +128,15 @@ public class StagGenerator {
                 .addTypeVariable(genericTypeName)
                 .returns(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), genericTypeName))
                 .addParameter(Gson.class, "gson")
-                .addParameter(ParameterizedTypeName.get(ClassName.get(TypeToken.class), genericTypeName), "type")
+                .addParameter(ParameterizedTypeName.get(ClassName.get(TypeToken.class), genericTypeName),
+                              "type")
                 .addCode("for (TypeAdapterFactory adapterFactory : mTypeAdapterFactories) {\n" +
-                        "\tTypeAdapter<T> typeAdapter = adapterFactory.create(gson, type);\n" +
-                        "\tif (typeAdapter != null) {\n" +
-                        "\t\treturn typeAdapter;\n" +
-                        "\t}\n" +
-                        "}\n" +
-                        "return null;\n");
+                         "\tTypeAdapter<T> typeAdapter = adapterFactory.create(gson, type);\n" +
+                         "\tif (typeAdapter != null) {\n" +
+                         "\t\treturn typeAdapter;\n" +
+                         "\t}\n" +
+                         "}\n" +
+                         "return null;\n");
 
         adapterFactoryBuilder.addMethod(createMethodBuilder.build());
         return adapterFactoryBuilder.build();

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
@@ -34,6 +34,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
+import com.vimeo.stag.processor.utils.FileGenUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -57,7 +58,8 @@ public class TypeAdapterFactoryGenerator {
      */
     @NotNull
     public TypeSpec getTypeAdapterFactorySpec() {
-        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(mInfo.getTypeAdapterFactoryClassName())
+        String className = FileGenUtils.desanitizeCode(mInfo.getTypeAdapterFactoryClassName());
+        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addSuperinterface(ClassName.get(TypeAdapterFactory.class))
                 .addMethod(getCreateMethodSpec());

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
@@ -58,7 +58,7 @@ public class TypeAdapterFactoryGenerator {
      */
     @NotNull
     public TypeSpec getTypeAdapterFactorySpec() {
-        String className = FileGenUtils.desanitizeCode(mInfo.getTypeAdapterFactoryClassName());
+        String className = FileGenUtils.unescapeEscapedString(mInfo.getTypeAdapterFactoryClassName());
         TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addSuperinterface(ClassName.get(TypeAdapterFactory.class))

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
@@ -58,10 +58,9 @@ public class TypeAdapterFactoryGenerator {
      */
     @NotNull
     public TypeSpec getTypeAdapterFactorySpec() {
-        TypeSpec.Builder adapterBuilder =
-                TypeSpec.classBuilder(mInfo.getTypeAdapterFactoryClassName())
-                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                        .addSuperinterface(ClassName.get(TypeAdapterFactory.class))
+        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(mInfo.getTypeAdapterFactoryClassName())
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addSuperinterface(ClassName.get(TypeAdapterFactory.class))
                 .addMethod(getCreateMethodSpec());
 
         return adapterBuilder.build();
@@ -82,10 +81,11 @@ public class TypeAdapterFactoryGenerator {
                 .addAnnotation(suppressions)
                 .addAnnotation(Override.class)
                 .addCode("Class<? super T> clazz = type.getRawType();\n" +
-                        "if (clazz == " + mInfo.getClassAndPackage() + ".class) {\n" +
-                        "\treturn (TypeAdapter<T>) new " + mInfo.getTypeAdapterQualifiedClassName() + "(gson);\n" +
-                        "}\n" +
-                        "return null;\n")
+                         "if (clazz == " + mInfo.getClassAndPackage() + ".class) {\n" +
+                         "\treturn (TypeAdapter<T>) new " + mInfo.getTypeAdapterQualifiedClassName() +
+                         "(gson);\n" +
+                         "}\n" +
+                         "return null;\n")
                 .build();
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterFactoryGenerator.java
@@ -39,7 +39,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.lang.model.element.Modifier;
 
-@SuppressWarnings("StringConcatenationMissingWhitespace")
 public class TypeAdapterFactoryGenerator {
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -101,7 +101,7 @@ public class TypeAdapterGenerator {
 
     @NotNull
     private static MethodSpec getWriteMethodSpec(@NotNull TypeName typeName,
-                                                 Map<Element, TypeMirror> memberVariables) {
+                                                 @NotNull Map<Element, TypeMirror> memberVariables) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("write")
                 .addParameter(JsonWriter.class, "writer")
                 .addParameter(typeName, "object")
@@ -137,7 +137,8 @@ public class TypeAdapterGenerator {
     }
 
     @NotNull
-    private MethodSpec getReadMethodSpec(TypeName typeName, Map<Element, TypeMirror> elements) {
+    private MethodSpec getReadMethodSpec(@NotNull TypeName typeName,
+                                         @NotNull Map<Element, TypeMirror> elements) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("read")
                 .addParameter(JsonReader.class, "reader")
                 .returns(typeName)
@@ -206,9 +207,9 @@ public class TypeAdapterGenerator {
         return builder.build();
     }
 
-    private static void addAdapterFields(TypeSpec.Builder adapterBuilder,
-                                         MethodSpec.Builder constructorBuilder,
-                                         Map<Element, TypeMirror> memberVariables) {
+    private static void addAdapterFields(@NotNull TypeSpec.Builder adapterBuilder,
+                                         @NotNull MethodSpec.Builder constructorBuilder,
+                                         @NotNull Map<Element, TypeMirror> memberVariables) {
         HashSet<TypeMirror> typeSet = new HashSet<>(memberVariables.values());
         for (TypeMirror fieldType : typeSet) {
             if (isNative(fieldType.toString())) {
@@ -228,12 +229,12 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private static TypeName getAdapterFieldTypeName(TypeMirror type) {
+    private static TypeName getAdapterFieldTypeName(@NotNull TypeMirror type) {
         TypeName typeName = TypeVariableName.get(type);
         return ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeName);
     }
 
-    private static String getAdapterField(TypeMirror type) {
+    private static String getAdapterField(@NotNull TypeMirror type) {
         ClassInfo classInfo = new ClassInfo(type);
         return "m" + classInfo.getTypeAdapterClassName();
     }
@@ -255,7 +256,7 @@ public class TypeAdapterGenerator {
     }
 
     @NotNull
-    private static String getJsonName(Element element) {
+    private static String getJsonName(@NotNull Element element) {
         String name = element.getAnnotation(GsonAdapterKey.class).value();
 
         if (name.isEmpty()) {
@@ -284,7 +285,9 @@ public class TypeAdapterGenerator {
 
     }
 
-    private static String getReadCode(String prefix, String variableName, TypeMirror type) {
+    @NotNull
+    private static String getReadCode(@NotNull String prefix, @NotNull String variableName,
+                                      @NotNull TypeMirror type) {
         if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             TypeMirror innerType = getInnerListType(type);
             String innerRead = getAdapterRead(innerType);
@@ -349,12 +352,12 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private static String getAdapterWrite(TypeMirror type, String variableName) {
+    private static String getAdapterWrite(@NotNull TypeMirror type, @NotNull String variableName) {
         String adapterField = getAdapterField(type);
         return adapterField + ".write(writer, " + variableName + ")";
     }
 
-    private static String getAdapterRead(TypeMirror type) {
+    private static String getAdapterRead(@NotNull TypeMirror type) {
         String adapterField = getAdapterField(type);
         return adapterField + ".read(reader)";
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -79,7 +79,7 @@ public class TypeAdapterGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(Gson.class, "gson");
 
-        String className = FileGenUtils.desanitizeCode(mInfo.getTypeAdapterClassName());
+        String className = FileGenUtils.unescapeEscapedString(mInfo.getTypeAdapterClassName());
         TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(className)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .superclass(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeVariableName));
@@ -223,7 +223,7 @@ public class TypeAdapterGenerator {
             TypeName typeName = getAdapterFieldTypeName(fieldType);
             String fieldName = getAdapterField(fieldType);
 
-            String originalFieldName = FileGenUtils.desanitizeCode(fieldName);
+            String originalFieldName = FileGenUtils.unescapeEscapedString(fieldName);
             adapterBuilder.addField(typeName, originalFieldName, Modifier.PRIVATE, Modifier.FINAL);
             constructorBuilder.addStatement(fieldName + " = gson.getAdapter(" + fieldType + ".class)");
         }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -254,7 +254,7 @@ public class TypeAdapterGenerator {
     private static String getJsonName(Element element) {
         String name = element.getAnnotation(GsonAdapterKey.class).value();
 
-        if (name == null || name.length() == 0) {
+        if (name.isEmpty()) {
             name = element.getSimpleName().toString();
         }
         return name;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -98,8 +98,8 @@ public class TypeAdapterGenerator {
     }
 
     @NotNull
-    private MethodSpec getWriteMethodSpec(@NotNull TypeName typeName,
-                                          Map<Element, TypeMirror> memberVariables) {
+    private static MethodSpec getWriteMethodSpec(@NotNull TypeName typeName,
+                                                 Map<Element, TypeMirror> memberVariables) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("write")
                 .addParameter(JsonWriter.class, "writer")
                 .addParameter(typeName, "object")
@@ -204,7 +204,7 @@ public class TypeAdapterGenerator {
         return builder.build();
     }
 
-    private void addAdapterFields(TypeSpec.Builder adapterBuilder, MethodSpec.Builder constructorBuilder,
+    private static void addAdapterFields(TypeSpec.Builder adapterBuilder, MethodSpec.Builder constructorBuilder,
                                   Map<Element, TypeMirror> memberVariables) {
         HashSet<TypeMirror> typeSet = new HashSet<>(memberVariables.values());
         for (TypeMirror fieldType : typeSet) {
@@ -224,12 +224,12 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private TypeName getAdapterFieldTypeName(TypeMirror type) {
+    private static TypeName getAdapterFieldTypeName(TypeMirror type) {
         TypeName typeName = TypeVariableName.get(type);
         return ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeName);
     }
 
-    private String getAdapterField(TypeMirror type) {
+    private static String getAdapterField(TypeMirror type) {
         ClassInfo classInfo = new ClassInfo(type);
         return "m" + classInfo.getTypeAdapterClassName();
     }
@@ -280,7 +280,7 @@ public class TypeAdapterGenerator {
 
     }
 
-    private String getReadCode(String prefix, String variableName, TypeMirror type) {
+    private static String getReadCode(String prefix, String variableName, TypeMirror type) {
         if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             TypeMirror innerType = getInnerListType(type);
             String innerRead = getAdapterRead(innerType);
@@ -297,7 +297,7 @@ public class TypeAdapterGenerator {
     }
 
     @NotNull
-    private String getReadType(@NotNull TypeMirror type) {
+    private static String getReadType(@NotNull TypeMirror type) {
         if (type.toString().equals(long.class.getName())) {
             return "reader.nextLong();";
         } else if (type.toString().equals(double.class.getName())) {
@@ -313,7 +313,7 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private String getWriteCode(@NotNull String prefix, @NotNull TypeMirror type, @NotNull String jsonName,
+    private static String getWriteCode(@NotNull String prefix, @NotNull TypeMirror type, @NotNull String jsonName,
                                 @NotNull String variableName) {
         if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             TypeMirror innerType = getInnerListType(type);
@@ -333,7 +333,7 @@ public class TypeAdapterGenerator {
 
 
     @NotNull
-    private String getWriteType(@NotNull TypeMirror type, @NotNull String variableName) {
+    private static String getWriteType(@NotNull TypeMirror type, @NotNull String variableName) {
         if (type.toString().equals(long.class.getName()) ||
             type.toString().equals(double.class.getName()) ||
             type.toString().equals(boolean.class.getName()) ||
@@ -345,12 +345,12 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private String getAdapterWrite(TypeMirror type, String variableName) {
+    private static String getAdapterWrite(TypeMirror type, String variableName) {
         String adapterField = getAdapterField(type);
         return adapterField + ".write(writer, " + variableName + ")";
     }
 
-    private String getAdapterRead(TypeMirror type) {
+    private static String getAdapterRead(TypeMirror type) {
         String adapterField = getAdapterField(type);
         return adapterField + ".read(reader)";
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -78,11 +78,9 @@ public class TypeAdapterGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(Gson.class, "gson");
 
-        TypeSpec.Builder adapterBuilder =
-                TypeSpec.classBuilder(mInfo.getTypeAdapterClassName())
-                        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-                        .superclass(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class),
-                                                              typeVariableName));
+        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(mInfo.getTypeAdapterClassName())
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .superclass(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeVariableName));
 
         AnnotatedClass annotatedClass = SupportedTypesModel.getInstance().getSupportedType(typeMirror);
         Map<Element, TypeMirror> memberVariables = annotatedClass.getMemberVariables();
@@ -100,10 +98,8 @@ public class TypeAdapterGenerator {
     }
 
     @NotNull
-    private MethodSpec getWriteMethodSpec(
-            @NotNull TypeName typeName,
-            Map<Element, TypeMirror> memberVariables
-    ) {
+    private MethodSpec getWriteMethodSpec(@NotNull TypeName typeName,
+                                          Map<Element, TypeMirror> memberVariables) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("write")
                 .addParameter(JsonWriter.class, "writer")
                 .addParameter(typeName, "object")
@@ -113,9 +109,9 @@ public class TypeAdapterGenerator {
                 .addException(IOException.class);
 
         builder.addCode("\tif (object == null) {\n" +
-                "\t\treturn;\n" +
-                "\t}\n" +
-                "\twriter.beginObject();\n");
+                        "\t\treturn;\n" +
+                        "\t}\n" +
+                        "\twriter.beginObject();\n");
 
         for (Map.Entry<Element, TypeMirror> element : memberVariables.entrySet()) {
             String name = getJsonName(element.getKey());
@@ -175,46 +171,46 @@ public class TypeAdapterGenerator {
 
             if (jsonTokenType != null) {
                 builder.addCode("\t\t\tcase \"" + name + "\":\n" +
-                        "\t\t\t\tif (jsonToken == " + jsonTokenType +
-                        ") {\n" +
-                        getReadCode("\t\t\t\t\t", variableName, element.getValue()) +
-                        "\n\t\t\t\t} else {" +
-                        "\n\t\t\t\t\treader.skipValue();" +
-                        "\n\t\t\t\t}" +
-                        '\n' +
-                        "\t\t\t\tbreak;\n");
+                                "\t\t\t\tif (jsonToken == " + jsonTokenType +
+                                ") {\n" +
+                                getReadCode("\t\t\t\t\t", variableName, element.getValue()) +
+                                "\n\t\t\t\t} else {" +
+                                "\n\t\t\t\t\treader.skipValue();" +
+                                "\n\t\t\t\t}" +
+                                '\n' +
+                                "\t\t\t\tbreak;\n");
             } else {
                 builder.addCode("\t\t\tcase \"" + name + "\":\n" +
-                        "\t\t\t\ttry {\n" +
-                        getReadCode("\t\t\t\t\t", variableName, element.getValue()) +
-                        "\n\t\t\t\t} catch(Exception exception) {" +
-                        "\n\t\t\t\t\tthrow new IOException(\"Error parsing " +
-                        mInfo.getClassName() + "." + variableName + " JSON!\", exception);" +
-                        "\n\t\t\t\t}" +
-                        '\n' +
-                        "\t\t\t\tbreak;\n");
+                                "\t\t\t\ttry {\n" +
+                                getReadCode("\t\t\t\t\t", variableName, element.getValue()) +
+                                "\n\t\t\t\t} catch(Exception exception) {" +
+                                "\n\t\t\t\t\tthrow new IOException(\"Error parsing " +
+                                mInfo.getClassName() + "." + variableName + " JSON!\", exception);" +
+                                "\n\t\t\t\t}" +
+                                '\n' +
+                                "\t\t\t\tbreak;\n");
             }
         }
 
         builder.addCode("\t\t\tdefault:\n" +
-                "\t\t\t\treader.skipValue();\n" +
-                "\t\t\t\tbreak;\n" +
-                "\t\t}\n" +
-                "\t}\n" +
-                '\n' +
-                "\treader.endObject();\n" +
-                "\treturn object;\n");
+                        "\t\t\t\treader.skipValue();\n" +
+                        "\t\t\t\tbreak;\n" +
+                        "\t\t}\n" +
+                        "\t}\n" +
+                        '\n' +
+                        "\treader.endObject();\n" +
+                        "\treturn object;\n");
 
         return builder.build();
     }
 
-    private void addAdapterFields(TypeSpec.Builder adapterBuilder,
-                                  MethodSpec.Builder constructorBuilder,
+    private void addAdapterFields(TypeSpec.Builder adapterBuilder, MethodSpec.Builder constructorBuilder,
                                   Map<Element, TypeMirror> memberVariables) {
         HashSet<TypeMirror> typeSet = new HashSet<>(memberVariables.values());
         for (TypeMirror fieldType : typeSet) {
-            if (isNative(fieldType.toString()))
+            if (isNative(fieldType.toString())) {
                 continue;
+            }
 
             if (TypeUtils.getOuterClassType(fieldType).equals(ArrayList.class.getName())) {
                 fieldType = getInnerListType(fieldType);
@@ -241,14 +237,13 @@ public class TypeAdapterGenerator {
 
     private static boolean isPrimitive(@NotNull String type) {
         return type.equals(long.class.getName()) ||
-                type.equals(double.class.getName()) ||
-                type.equals(boolean.class.getName()) ||
-                type.equals(int.class.getName());
+               type.equals(double.class.getName()) ||
+               type.equals(boolean.class.getName()) ||
+               type.equals(int.class.getName());
     }
 
     private static boolean isNative(@NotNull String type) {
-        return isPrimitive(type) ||
-                type.equals(String.class.getName());
+        return isPrimitive(type) || type.equals(String.class.getName());
     }
 
     private static TypeMirror getInnerListType(@NotNull TypeMirror type) {
@@ -285,28 +280,24 @@ public class TypeAdapterGenerator {
 
     }
 
-    private String getReadCode(
-            String prefix,
-            String variableName,
-            TypeMirror type) {
+    private String getReadCode(String prefix, String variableName, TypeMirror type) {
         if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             TypeMirror innerType = getInnerListType(type);
             String innerRead = getAdapterRead(innerType);
             return prefix + "reader.beginArray();\n" +
-                    prefix + "object." + variableName + " = new java.util.ArrayList<>();\n" +
-                    prefix + "while (reader.hasNext()) {\n" +
-                    prefix + "\tobject." + variableName + ".add(" + innerRead + ");\n" +
-                    prefix + "}\n" +
-                    prefix + "reader.endArray();";
+                   prefix + "object." + variableName + " = new java.util.ArrayList<>();\n" +
+                   prefix + "while (reader.hasNext()) {\n" +
+                   prefix + "\tobject." + variableName + ".add(" + innerRead + ");\n" +
+                   prefix + "}\n" +
+                   prefix + "reader.endArray();";
         } else {
             return prefix + "object." + variableName + " = " +
-                    getReadType(type);
+                   getReadType(type);
         }
     }
 
     @NotNull
-    private String getReadType(
-            @NotNull TypeMirror type) {
+    private String getReadType(@NotNull TypeMirror type) {
         if (type.toString().equals(long.class.getName())) {
             return "reader.nextLong();";
         } else if (type.toString().equals(double.class.getName())) {
@@ -322,52 +313,44 @@ public class TypeAdapterGenerator {
         }
     }
 
-    private String getWriteCode(
-            @NotNull String prefix,
-            @NotNull TypeMirror type,
-            @NotNull String jsonName,
-            @NotNull String variableName
-    ) {
+    private String getWriteCode(@NotNull String prefix, @NotNull TypeMirror type, @NotNull String jsonName,
+                                @NotNull String variableName) {
         if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             TypeMirror innerType = getInnerListType(type);
             String innerWrite = getAdapterWrite(innerType, "item");
             return prefix + "writer.name(\"" + jsonName + "\");\n" +
-                    prefix + "writer.beginArray();\n" +
-                    prefix + "for (" + innerType + " item : " + variableName + ") {\n" +
-                    prefix + "\t" + innerWrite + ";\n" +
-                    prefix + "}\n" +
-                    prefix + "writer.endArray();\n";
+                   prefix + "writer.beginArray();\n" +
+                   prefix + "for (" + innerType + " item : " + variableName + ") {\n" +
+                   prefix + "\t" + innerWrite + ";\n" +
+                   prefix + "}\n" +
+                   prefix + "writer.endArray();\n";
         } else {
             return prefix + "writer.name(\"" + jsonName + "\");\n" +
-                    prefix + getWriteType(type, variableName) + '\n';
+                   prefix + getWriteType(type, variableName) + '\n';
 
         }
     }
 
 
     @NotNull
-    private String getWriteType(
-            @NotNull TypeMirror type,
-            @NotNull String variableName) {
+    private String getWriteType(@NotNull TypeMirror type, @NotNull String variableName) {
         if (type.toString().equals(long.class.getName()) ||
-                type.toString().equals(double.class.getName()) ||
-                type.toString().equals(boolean.class.getName()) ||
-                type.toString().equals(String.class.getName()) ||
-                type.toString().equals(int.class.getName())) {
+            type.toString().equals(double.class.getName()) ||
+            type.toString().equals(boolean.class.getName()) ||
+            type.toString().equals(String.class.getName()) ||
+            type.toString().equals(int.class.getName())) {
             return "writer.value(" + variableName + ");";
         } else {
             return getAdapterWrite(type, variableName) + ";";
         }
     }
 
-    private String getAdapterWrite(TypeMirror type, String variableName)
-    {
+    private String getAdapterWrite(TypeMirror type, String variableName) {
         String adapterField = getAdapterField(type);
         return adapterField + ".write(writer, " + variableName + ")";
     }
 
-    private String getAdapterRead(TypeMirror type)
-    {
+    private String getAdapterRead(TypeMirror type) {
         String adapterField = getAdapterField(type);
         return adapterField + ".read(reader)";
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -79,7 +79,7 @@ public class ClassInfo {
      */
     @NotNull
     public String getTypeAdapterClassName() {
-        return FileGenUtils.sanitizeCode(mClassName + "$TypeAdapter");
+        return FileGenUtils.escapeStringForCodeBlock(mClassName + "$TypeAdapter");
     }
 
     /**
@@ -101,7 +101,7 @@ public class ClassInfo {
      */
     @NotNull
     public String getTypeAdapterFactoryClassName() {
-        return FileGenUtils.sanitizeCode(mClassName + "$TypeAdapterFactory");
+        return FileGenUtils.escapeStringForCodeBlock(mClassName + "$TypeAdapterFactory");
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -24,6 +24,7 @@
 package com.vimeo.stag.processor.generators.model;
 
 import com.vimeo.stag.processor.utils.ElementUtils;
+import com.vimeo.stag.processor.utils.FileGenUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -78,7 +79,7 @@ public class ClassInfo {
      */
     @NotNull
     public String getTypeAdapterClassName() {
-        return mClassName + "TypeAdapter";
+        return FileGenUtils.sanitizeCode(mClassName + "$TypeAdapter");
     }
 
     /**
@@ -100,7 +101,7 @@ public class ClassInfo {
      */
     @NotNull
     public String getTypeAdapterFactoryClassName() {
-        return mClassName + "TypeAdapterFactory";
+        return FileGenUtils.sanitizeCode(mClassName + "$TypeAdapterFactory");
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -88,18 +87,6 @@ public final class SupportedTypesModel {
             addSupportedType(model);
         }
         return model;
-    }
-
-    /**
-     * A list of all supported AnnotatedClasses.
-     * This may return both generic and concrete
-     * types.
-     *
-     * @return the list of all supported types.
-     */
-    @NotNull
-    public List<AnnotatedClass> getSupportedTypes() {
-        return new ArrayList<>(mSupportedTypesMap.values());
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/DebugLog.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/DebugLog.java
@@ -33,6 +33,7 @@ public final class DebugLog {
     private static final String TAG = "Stag";
 
     private DebugLog() {
+        throw new UnsupportedOperationException("This class is not instantiable");
     }
 
     public static void log(@Nullable CharSequence message) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -51,7 +51,7 @@ public final class ElementUtils {
     public static TypeMirror getTypeFromQualifiedName(@NotNull String qualifiedName) {
         Elements elements = ElementUtils.getUtils();
         TypeElement typeElement = elements.getTypeElement(qualifiedName);
-        return  typeElement.asType();
+        return typeElement.asType();
     }
 
     public static String getPackage(@NotNull TypeMirror type) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -24,6 +24,7 @@
 package com.vimeo.stag.processor.utils;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
@@ -48,7 +49,7 @@ public final class ElementUtils {
         return sElementUtils;
     }
 
-    @NotNull
+    @Nullable
     public static TypeMirror getTypeFromQualifiedName(@NotNull String qualifiedName) {
         Elements elements = ElementUtils.getUtils();
         TypeElement typeElement = elements.getTypeElement(qualifiedName);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -43,17 +43,19 @@ public final class ElementUtils {
         sElementUtils = elementUtils;
     }
 
-    public static Elements getUtils() {
+    private static Elements getUtils() {
         Preconditions.checkNotNull(sElementUtils);
         return sElementUtils;
     }
 
+    @NotNull
     public static TypeMirror getTypeFromQualifiedName(@NotNull String qualifiedName) {
         Elements elements = ElementUtils.getUtils();
         TypeElement typeElement = elements.getTypeElement(qualifiedName);
         return typeElement.asType();
     }
 
+    @NotNull
     public static String getPackage(@NotNull TypeMirror type) {
         Element element = TypeUtils.getUtils().asElement(type);
         PackageElement packageElement = sElementUtils.getPackageOf(element);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
@@ -23,6 +23,7 @@
  */
 package com.vimeo.stag.processor.utils;
 
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 
 import org.jetbrains.annotations.NotNull;
@@ -135,6 +136,31 @@ public final class FileGenUtils {
         } catch (IOException e) {
             // ignored
         }
+    }
+
+    /**
+     * Takes a String input and sanitizes it for use
+     * in the {@link CodeBlock} class.
+     *
+     * @param string the string to sanitize.
+     * @return a String safe to use in a {@link CodeBlock}
+     */
+    @NotNull
+    public static String sanitizeCode(@NotNull String string) {
+        return string.replace("$", "$$");
+    }
+
+    /**
+     * Takes a String input that was sanitized for
+     * use in the {@link CodeBlock} class and
+     * desanitizes it for normal use.
+     *
+     * @param string the String to desanitize,
+     * @return a String safe for normal use.
+     */
+    @NotNull
+    public static String desanitizeCode(@NotNull String string) {
+        return string.replace("$$", "$");
     }
 
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
@@ -83,7 +83,8 @@ public final class FileGenUtils {
 
     static CharSequence readResource(@NotNull Filer filer, @NotNull String resourceName) throws IOException {
         try {
-            FileObject file = filer.getResource(StandardLocation.CLASS_OUTPUT, GENERATED_PACKAGE_NAME, resourceName);
+            FileObject file =
+                    filer.getResource(StandardLocation.CLASS_OUTPUT, GENERATED_PACKAGE_NAME, resourceName);
             return file.getCharContent(false);
         } catch (FileNotFoundException e) {
             DebugLog.log("Resource not found: " + resourceName);
@@ -91,8 +92,10 @@ public final class FileGenUtils {
         }
     }
 
-    static void writeToResource(@NotNull Filer filer, @NotNull String resourceName, @NotNull CharSequence content) throws IOException {
-        FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT, GENERATED_PACKAGE_NAME, resourceName);
+    static void writeToResource(@NotNull Filer filer, @NotNull String resourceName,
+                                @NotNull CharSequence content) throws IOException {
+        FileObject file =
+                filer.createResource(StandardLocation.CLASS_OUTPUT, GENERATED_PACKAGE_NAME, resourceName);
         file.delete();
         Writer writer = null;
         try {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
@@ -44,8 +44,11 @@ import javax.tools.StandardLocation;
 public final class FileGenUtils {
 
     public static final String GENERATED_PACKAGE_NAME = "com.vimeo.stag.generated";
+    private static final String UNESCAPED_SEPARATOR = "$";
+    private static final String CODE_BLOCK_ESCAPED_SEPARATOR = "$$";
 
     private FileGenUtils() {
+        throw new UnsupportedOperationException("This class is not instantiable");
     }
 
     /**
@@ -139,28 +142,28 @@ public final class FileGenUtils {
     }
 
     /**
-     * Takes a String input and sanitizes it for use
+     * Takes a String input and escapes it for use
      * in the {@link CodeBlock} class.
      *
-     * @param string the string to sanitize.
+     * @param string the string to escape.
      * @return a String safe to use in a {@link CodeBlock}
      */
     @NotNull
-    public static String sanitizeCode(@NotNull String string) {
-        return string.replace("$", "$$");
+    public static String escapeStringForCodeBlock(@NotNull String string) {
+        return string.replace(UNESCAPED_SEPARATOR, CODE_BLOCK_ESCAPED_SEPARATOR);
     }
 
     /**
-     * Takes a String input that was sanitized for
+     * Takes a String input that was escaped for
      * use in the {@link CodeBlock} class and
-     * desanitizes it for normal use.
+     * unescapes it for normal use.
      *
-     * @param string the String to desanitize,
+     * @param string the String to unescape,
      * @return a String safe for normal use.
      */
     @NotNull
-    public static String desanitizeCode(@NotNull String string) {
-        return string.replace("$$", "$");
+    public static String unescapeEscapedString(@NotNull String string) {
+        return string.replace(CODE_BLOCK_ESCAPED_SEPARATOR, UNESCAPED_SEPARATOR);
     }
 
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
@@ -26,7 +26,9 @@ package com.vimeo.stag.processor.utils;
 import com.squareup.javapoet.JavaFile;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
@@ -116,6 +118,22 @@ public final class FileGenUtils {
 
                 }
             }
+        }
+    }
+
+    /**
+     * Safely closes a closeable.
+     *
+     * @param closeable object to close.
+     */
+    static void close(@Nullable Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (IOException e) {
+            // ignored
         }
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -78,9 +79,7 @@ public class KnownTypeAdapterFactoriesUtils {
             return;
         }
         String[] knownFactories = content.toString().split("[\\n\\r]+");
-        for (String knownFactory : knownFactories) {
-            resultSet.add(knownFactory);
-        }
+        Collections.addAll(resultSet, knownFactories);
     }
 
     private static void loadKnownTypesFromClasspath(Set<String> resultSet) throws IOException {
@@ -97,7 +96,7 @@ public class KnownTypeAdapterFactoriesUtils {
                     resultSet.add(line.trim());
                 }
             } finally {
-                inputStream.close();
+                FileGenUtils.close(inputStream);
             }
         }
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -39,9 +39,12 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
-public class KnownTypeAdapterFactoriesUtils {
+public final class KnownTypeAdapterFactoriesUtils {
 
     private static final String KNOWN_FACTORIES_RESOURCE = "StagTypeAdapterFactory.list";
+
+    private KnownTypeAdapterFactoriesUtils() {
+    }
 
     public static Set<String> loadKnownTypes(ProcessingEnvironment processingEnv) throws IOException {
         Filer filer = processingEnv.getFiler();

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -23,6 +23,8 @@
  */
 package com.vimeo.stag.processor.utils;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,7 +48,8 @@ public final class KnownTypeAdapterFactoriesUtils {
     private KnownTypeAdapterFactoriesUtils() {
     }
 
-    public static Set<String> loadKnownTypes(ProcessingEnvironment processingEnv) throws IOException {
+    public static Set<String> loadKnownTypes(@NotNull ProcessingEnvironment processingEnv)
+            throws IOException {
         Filer filer = processingEnv.getFiler();
         LinkedHashSet<String> knownTypes = new LinkedHashSet<>();
         loadKnownTypesFromFiler(filer, knownTypes);
@@ -66,8 +69,8 @@ public final class KnownTypeAdapterFactoriesUtils {
         return knownTypes;
     }
 
-    public static void writeKnownTypes(ProcessingEnvironment processingEnv, Set<String> knownTypes)
-            throws IOException {
+    public static void writeKnownTypes(@NotNull ProcessingEnvironment processingEnv,
+                                       @NotNull Set<String> knownTypes) throws IOException {
         Filer filer = processingEnv.getFiler();
         StringBuilder knownTypesBuilder = new StringBuilder();
         for (String knownType : knownTypes) {
@@ -76,7 +79,8 @@ public final class KnownTypeAdapterFactoriesUtils {
         FileGenUtils.writeToResource(filer, KNOWN_FACTORIES_RESOURCE, knownTypesBuilder.toString());
     }
 
-    private static void loadKnownTypesFromFiler(Filer filer, Set<String> resultSet) throws IOException {
+    private static void loadKnownTypesFromFiler(@NotNull Filer filer, @NotNull Set<String> resultSet)
+            throws IOException {
         CharSequence content = FileGenUtils.readResource(filer, KNOWN_FACTORIES_RESOURCE);
         if (content == null) {
             return;
@@ -85,7 +89,7 @@ public final class KnownTypeAdapterFactoriesUtils {
         Collections.addAll(resultSet, knownFactories);
     }
 
-    private static void loadKnownTypesFromClasspath(Set<String> resultSet) throws IOException {
+    private static void loadKnownTypesFromClasspath(@NotNull Set<String> resultSet) throws IOException {
         ClassLoader classLoader = KnownTypeAdapterFactoriesUtils.class.getClassLoader();
         String resourcePath = FileGenUtils.GENERATED_PACKAGE_NAME.replace('.', '/');
         Enumeration<URL> resources = classLoader.getResources(resourcePath + "/" + KNOWN_FACTORIES_RESOURCE);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -46,6 +46,7 @@ public final class KnownTypeAdapterFactoriesUtils {
     private static final String KNOWN_FACTORIES_RESOURCE = "StagTypeAdapterFactory.list";
 
     private KnownTypeAdapterFactoriesUtils() {
+        throw new UnsupportedOperationException("This class is not instantiable");
     }
 
     public static Set<String> loadKnownTypes(@NotNull ProcessingEnvironment processingEnv)

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -62,7 +62,8 @@ public class KnownTypeAdapterFactoriesUtils {
         return knownTypes;
     }
 
-    public static void writeKnownTypes(ProcessingEnvironment processingEnv, Set<String> knownTypes) throws IOException {
+    public static void writeKnownTypes(ProcessingEnvironment processingEnv, Set<String> knownTypes)
+            throws IOException {
         Filer filer = processingEnv.getFiler();
         StringBuilder knownTypesBuilder = new StringBuilder();
         for (String knownType : knownTypes) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/Preconditions.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/Preconditions.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
 public final class Preconditions {
 
     private Preconditions() {
-        throw new UnsupportedOperationException("This class is instantiable");
+        throw new UnsupportedOperationException("This class is not instantiable");
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -45,7 +45,7 @@ public final class TypeUtils {
     private static Types sTypeUtils;
 
     private TypeUtils() {
-        throw new UnsupportedOperationException("This class is instantiable");
+        throw new UnsupportedOperationException("This class is not instantiable");
     }
 
     public static void initialize(@NotNull Types typeUtils) {
@@ -104,7 +104,7 @@ public final class TypeUtils {
     /**
      * Determines whether or not the TypeMirror is a concrete type.
      * If the type is a generic type or contains generic type
-     * arguments (i.e. a paramenterized type), this method will
+     * arguments (i.e. a parameterized type), this method will
      * return false.
      *
      * @param typeMirror the element to check.


### PR DESCRIPTION
#### Summary
Preparing for release. Cleaned up code and formatting, and fixed lint warnings. Additionally, changed the names of the factories and adapters generated to include $ as a separator in order to not pollute the user's namespace unnecessarily, since these classes are now housed in their models' packages.
