### PR TITLE
List adapter field fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The Stag library solves this problem. It leverages annotations to automatically 
 from jCenter
 ```groovy
 dependencies {
-    compile 'com.vimeo.stag:stag-library:1.1.0'
-    apt 'com.vimeo.stag:stag-library-compiler:1.1.0'
+    compile 'com.vimeo.stag:stag-library:1.1.1'
+    apt 'com.vimeo.stag:stag-library-compiler:1.1.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ allprojects {
 
 subprojects {
     group = 'com.vimeo.stag'
-    version = '1.1.0'
+    version = '1.1.1'
 }

--- a/sample/src/main/java/com/vimeo/sample/model/IdenticalFieldTypes.java
+++ b/sample/src/main/java/com/vimeo/sample/model/IdenticalFieldTypes.java
@@ -1,0 +1,26 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import java.util.ArrayList;
+
+public class IdenticalFieldTypes {
+
+    @GsonAdapterKey
+    User mUser;
+
+    @GsonAdapterKey
+    User mSecondUser;
+
+    @GsonAdapterKey
+    ArrayList<User> mUsersList;
+
+    @GsonAdapterKey
+    ArrayList<User> mSecondUsersList;
+
+    @GsonAdapterKey
+    ArrayList<Stats> mStatsArrayList;
+
+    @GsonAdapterKey
+    Stats mStats;
+}

--- a/sample/src/main/java/com/vimeo/sample/model/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model/Video.java
@@ -25,12 +25,25 @@ package com.vimeo.sample.model;
 
 import com.vimeo.stag.GsonAdapterKey;
 
+import java.util.ArrayList;
 import java.util.Date;
 
 public class Video {
 
     @GsonAdapterKey("user")
     public User mUser;
+
+    @GsonAdapterKey("secondUser")
+    public User mSecondUser;
+
+    @GsonAdapterKey
+    ArrayList<User> mUsersList;
+
+    @GsonAdapterKey
+    ArrayList<User> mSecondUsersList;
+
+    @GsonAdapterKey
+    public ArrayList<Stats> mStatsArrayList;
 
     @GsonAdapterKey("link")
     public String mLink;

--- a/sample/src/main/java/com/vimeo/sample/model/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model/Video.java
@@ -25,25 +25,12 @@ package com.vimeo.sample.model;
 
 import com.vimeo.stag.GsonAdapterKey;
 
-import java.util.ArrayList;
 import java.util.Date;
 
 public class Video {
 
     @GsonAdapterKey("user")
     public User mUser;
-
-    @GsonAdapterKey("secondUser")
-    public User mSecondUser;
-
-    @GsonAdapterKey
-    ArrayList<User> mUsersList;
-
-    @GsonAdapterKey
-    ArrayList<User> mSecondUsersList;
-
-    @GsonAdapterKey
-    public ArrayList<Stats> mStatsArrayList;
 
     @GsonAdapterKey("link")
     public String mLink;


### PR DESCRIPTION
#### Ticket Summary
There is an issue with List types in that the actual parameterized type is being added as an adapter field, even if that type exists. For most types this is already prevented by using a HashSet, however, lists can get around this.

#### Implementation Summary
I created a second HashSet, and iterate over the first to create the second, then use the second to add the adapter fields. I also added a try/catch around ArrayList inner read calls to be in line with other object read calls.

Bumping version to 1.1.1. I will update the readme once it this is approved before deployment.

#### How to Test
I changed the Video model to have a bunch of duplicate types and ArrayLists. Verify the Video TypeAdapter is correctly generated.