### PR TITLE
Support for TypeTokens for complex Data Structures and Performance Improvements

### DIFF
--- a/sample/src/main/java/com/vimeo/sample/model/NestedModel.java
+++ b/sample/src/main/java/com/vimeo/sample/model/NestedModel.java
@@ -1,0 +1,14 @@
+package com.vimeo.sample.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/*
+    This is to simulate a scenario where a class with the same name is present as
+    a static inner class for another class in the same package
+ */
+
+public class NestedModel {
+
+    @SerializedName("test1")
+    public String test1;
+}

--- a/sample/src/main/java/com/vimeo/sample/model/NestedModel.java
+++ b/sample/src/main/java/com/vimeo/sample/model/NestedModel.java
@@ -1,6 +1,7 @@
 package com.vimeo.sample.model;
 
 import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.GsonAdapterKey;
 
 /*
     This is to simulate a scenario where a class with the same name is present as
@@ -9,6 +10,6 @@ import com.google.gson.annotations.SerializedName;
 
 public class NestedModel {
 
-    @SerializedName("test1")
+    @GsonAdapterKey("test1")
     public String test1;
 }

--- a/sample/src/main/java/com/vimeo/sample/model/TypeTokenBasedModels.java
+++ b/sample/src/main/java/com/vimeo/sample/model/TypeTokenBasedModels.java
@@ -1,0 +1,15 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.stag.GsonAdapterKey;
+
+import java.util.List;
+import java.util.Map;
+
+public class TypeTokenBasedModels {
+
+    @GsonAdapterKey("videoMap")
+    public Map<String, Video> videoMap;
+
+    @GsonAdapterKey("videoList")
+    public List<Video> videoList;
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -29,6 +29,7 @@ import com.vimeo.stag.GsonAdapterKey;
 import com.vimeo.stag.processor.generators.StagGenerator;
 import com.vimeo.stag.processor.generators.TypeAdapterFactoryGenerator;
 import com.vimeo.stag.processor.generators.TypeAdapterGenerator;
+import com.vimeo.stag.processor.generators.TypeTokenConstantsGenerator;
 import com.vimeo.stag.processor.generators.model.AnnotatedClass;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
 import com.vimeo.stag.processor.generators.model.SupportedTypesModel;
@@ -139,13 +140,15 @@ public final class StagProcessor extends AbstractProcessor {
             StagGenerator adapterGenerator = new StagGenerator(filer, mSupportedTypes);
             adapterGenerator.generateTypeAdapterFactory();
 
+            TypeTokenConstantsGenerator typeTokenConstantsGenerator = new TypeTokenConstantsGenerator(filer);
+
             Set<Element> list = SupportedTypesModel.getInstance().getSupportedElements();
             for (Element element : list) {
                 if (TypeUtils.isConcreteType(element)) {
                     ClassInfo classInfo = new ClassInfo(element.asType());
                     TypeAdapterGenerator independentAdapter = new TypeAdapterGenerator(classInfo);
                     JavaFile javaFile = JavaFile.builder(classInfo.getPackageName(),
-                                                         independentAdapter.getTypeAdapterSpec()).build();
+                                                         independentAdapter.getTypeAdapterSpec(typeTokenConstantsGenerator)).build();
                     FileGenUtils.writeToFile(javaFile, filer);
 
                     TypeAdapterFactoryGenerator factoryGenerator = new TypeAdapterFactoryGenerator(classInfo);
@@ -155,6 +158,7 @@ public final class StagProcessor extends AbstractProcessor {
                 }
             }
 
+            typeTokenConstantsGenerator.generateTypeTokenConstants();
             KnownTypeAdapterFactoriesUtils.writeKnownTypes(processingEnv, mSupportedTypes);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -245,11 +245,11 @@ public class TypeAdapterGenerator {
         return "m" + classInfo.getTypeAdapterClassName();
     }
 
-
     private static boolean isPrimitive(@NotNull String type) {
         return type.equals(long.class.getName()) ||
                type.equals(double.class.getName()) ||
                type.equals(boolean.class.getName()) ||
+                type.equals(float.class.getName()) ||
                type.equals(int.class.getName());
     }
 
@@ -283,12 +283,13 @@ public class TypeAdapterGenerator {
             return "com.google.gson.stream.JsonToken.STRING";
         } else if (type.toString().equals(int.class.getName())) {
             return "com.google.gson.stream.JsonToken.NUMBER";
+        } else if (type.toString().equals(float.class.getName())) {
+            return "com.google.gson.stream.JsonToken.NUMBER";
         } else if (TypeUtils.getOuterClassType(type).equals(ArrayList.class.getName())) {
             return "com.google.gson.stream.JsonToken.BEGIN_ARRAY";
         } else {
             return null;
         }
-
     }
 
     @NotNull
@@ -328,6 +329,8 @@ public class TypeAdapterGenerator {
             return "reader.nextString();";
         } else if (type.toString().equals(int.class.getName())) {
             return "reader.nextInt();";
+        } else if (type.toString().equals(float.class.getName())) {
+            return "(float) reader.nextDouble();";
         } else {
             return getAdapterRead(type) + ";";
         }
@@ -351,14 +354,14 @@ public class TypeAdapterGenerator {
         }
     }
 
-
     @NotNull
     private static String getWriteType(@NotNull TypeMirror type, @NotNull String variableName) {
         if (type.toString().equals(long.class.getName()) ||
             type.toString().equals(double.class.getName()) ||
             type.toString().equals(boolean.class.getName()) ||
             type.toString().equals(String.class.getName()) ||
-            type.toString().equals(int.class.getName())) {
+                type.toString().equals(int.class.getName()) ||
+                type.toString().equals(float.class.getName())) {
             return "writer.value(" + variableName + ");";
         } else {
             return getAdapterWrite(type, variableName) + ";";
@@ -374,5 +377,4 @@ public class TypeAdapterGenerator {
         String adapterField = getAdapterField(type);
         return adapterField + ".read(reader)";
     }
-
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -162,12 +162,14 @@ public class TypeAdapterGenerator {
 
         for (TypeMirror fieldType : exclusiveTypeSet) {
             TypeName typeName = getAdapterFieldTypeName(fieldType);
-            String fieldName = TYPE_ADAPTER_FIELD_PREFIX + typeAdapterNamesMap.size();
-            typeAdapterNamesMap.put(fieldType.toString(), fieldName);
-
-            String originalFieldName = FileGenUtils.unescapeEscapedString(fieldName);
-            adapterBuilder.addField(typeName, originalFieldName, Modifier.PRIVATE, Modifier.FINAL);
-            constructorBuilder.addStatement(fieldName + " = gson.getAdapter(" + typeTokenConstantsGenerator.addTypeToken(fieldType) + ")");
+            String fieldName = typeAdapterNamesMap.get(fieldType.toString());
+            if (null == fieldName) {
+                fieldName = TYPE_ADAPTER_FIELD_PREFIX + typeAdapterNamesMap.size();
+                typeAdapterNamesMap.put(fieldType.toString(), fieldName);
+                String originalFieldName = FileGenUtils.unescapeEscapedString(fieldName);
+                adapterBuilder.addField(typeName, originalFieldName, Modifier.PRIVATE, Modifier.FINAL);
+                constructorBuilder.addStatement(fieldName + " = gson.getAdapter(" + typeTokenConstantsGenerator.addTypeToken(fieldType) + ")");
+            }
         }
 
         return typeAdapterNamesMap;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -363,10 +363,6 @@ public class TypeAdapterGenerator {
                 builder.addCode("\t\t\tcase \"" + name + "\":\n" +
                         "\t\t\t\ttry {\n" +
                         getReadCode("\t\t\t\t\t", variableName, element.getValue(), typeAdapterFieldMap) +
-                        "\n\t\t\t\t} catch(Exception exception) {" +
-                        "\n\t\t\t\t\tthrow new IOException(\"Error parsing " +
-                        mInfo.getClassName() + "." + variableName + " JSON!\", exception);" +
-                        "\n\t\t\t\t}" +
                         '\n' +
                         "\t\t\t\tbreak;\n");
             }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -114,10 +114,11 @@ public class TypeAdapterGenerator {
                 .addAnnotation(Override.class)
                 .addException(IOException.class);
 
-        builder.addCode("\tif (object == null) {\n" +
+        builder.addCode("\twriter.beginObject();\n" +
+                "\tif (object == null) {\n" +
+                "\t\twriter.endObject();\n" +
                 "\t\treturn;\n" +
-                "\t}\n" +
-                "\twriter.beginObject();\n");
+                "\t}\n");
 
         for (Map.Entry<Element, TypeMirror> element : memberVariables.entrySet()) {
             String name = getJsonName(element.getKey());

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -237,7 +237,6 @@ public class TypeAdapterGenerator {
     @NotNull
     private static String getReadCode(@NotNull String prefix, @NotNull String variableName,
                                       @NotNull TypeMirror type, @NotNull Map<String, String> typeAdapterFieldMap) {
-        String outerClassType = TypeUtils.getOuterClassType(type);
         if (isArray(type)) {
             TypeMirror innerType = getInnerListType(type);
             String innerRead = getReadType(innerType, typeAdapterFieldMap);
@@ -364,7 +363,6 @@ public class TypeAdapterGenerator {
                         "\t\t\t\tbreak;\n");
             } else {
                 builder.addCode("\t\t\tcase \"" + name + "\":\n" +
-                        "\t\t\t\ttry {\n" +
                         getReadCode("\t\t\t\t\t", variableName, element.getValue(), typeAdapterFieldMap) +
                         '\n' +
                         "\t\t\t\tbreak;\n");

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeTokenConstantsGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeTokenConstantsGenerator.java
@@ -1,0 +1,88 @@
+package com.vimeo.stag.processor.generators;
+
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeVariableName;
+import com.vimeo.stag.processor.utils.FileGenUtils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.processing.Filer;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.TypeMirror;
+
+public class TypeTokenConstantsGenerator {
+
+    private static final String CLASS_STAG_TYPE_TOKEN_CONSTANTS = "StagTypeTokenConstants";
+
+    private static final String FIELD_PREFIX = "TYPE_TOKEN_";
+
+    @NotNull
+    private final Filer mFiler;
+
+    @NotNull
+    private final HashMap<TypeMirror, String> mTypesToBeGenerated = new HashMap<>();
+
+    public TypeTokenConstantsGenerator(@NotNull Filer filer) {
+        mFiler = filer;
+    }
+
+    public String addTypeToken(@NotNull TypeMirror type) {
+        String result = mTypesToBeGenerated.get(type);
+        if(null == result) {
+            result = FIELD_PREFIX + mTypesToBeGenerated.size();
+            mTypesToBeGenerated.put(type, result);
+        }
+        return FileGenUtils.GENERATED_PACKAGE_NAME + "." + CLASS_STAG_TYPE_TOKEN_CONSTANTS + "." + result;
+    }
+
+
+    /**
+     * Generates the public API in the form of the {@code Stag.Factory} type adapter factory
+     * for the annotated classes.
+     *
+     * @throws IOException throws an exception
+     *                     if we are unable to write the file
+     *                     to the filesystem.
+     */
+    public void generateTypeTokenConstants() throws IOException {
+        if(!mTypesToBeGenerated.isEmpty()) {
+            TypeSpec.Builder adaptersBuilder =
+                    TypeSpec.classBuilder(CLASS_STAG_TYPE_TOKEN_CONSTANTS).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
+            for(Map.Entry<TypeMirror, String > entry : mTypesToBeGenerated.entrySet()) {
+                TypeMirror type = entry.getKey();
+                TypeName typeName = TypeVariableName.get(type);
+                TypeName parameterizedTypeName =  ParameterizedTypeName.get(ClassName.get(TypeToken.class), typeName);
+                FieldSpec.Builder fieldSpecBuilder = FieldSpec.builder(parameterizedTypeName, entry.getValue(), Modifier.STATIC, Modifier.FINAL, Modifier.PUBLIC);
+                fieldSpecBuilder.initializer("new com.google.gson.reflect.TypeToken<" + typeName + ">(){}");
+                adaptersBuilder.addField(fieldSpecBuilder.build());
+            }
+
+            JavaFile javaFile =
+                    JavaFile.builder(FileGenUtils.GENERATED_PACKAGE_NAME, adaptersBuilder.build()).build();
+
+            FileGenUtils.writeToFile(javaFile, mFiler);
+        }
+    }
+
+
+
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -47,8 +47,7 @@ public class ClassInfo {
         mPackageName = ElementUtils.getPackage(typeMirror);
 
         String classAndPackage = typeMirror.toString();
-        String simplePackage = classAndPackage.substring(0, classAndPackage.lastIndexOf('.'));
-        mClassName = classAndPackage.substring(simplePackage.length() + 1, classAndPackage.length());
+        mClassName = classAndPackage.substring(mPackageName.length() + 1, classAndPackage.length()).replaceAll("\\.", "\\$");
     }
 
     /**


### PR DESCRIPTION
Code Changes Description :

**1. Support for TypeToken which will allow more complex types to be supported by Stag** : We added the support for typetokens which will now allow complex types such as HashMap, ArrayList<ArrayList> etc, to be supported. These typetokens will be created as a static final member variable in StagTypeTokenConstants.java file, while keeping a reference to the generated typetokens so that we do not create the typetoken of same type twice.

Performance Improvements : 

Previously, in the TypeAdapter constructor, TypeToken.get(type) was being used. This internally creates a new typetoken for the type. Since creating new typetokens are really cpu intensive, this could lead to performance degradation. This was solved by keeping the reference to the typetokens that were generated in the StagTypeTokenConstants.java file and reusing them.

Testing : Use HashMaps or any other complex data type as a field in the class to be generated.

**2. Support for float data type**

Testing : Create a float variable in a class.

**3. Change in name convention for generating typeadapter files** : In case a class of same name is present in same package as a static inner class and an outer class as well, this resulted in generation of typeadapter files with same name. 

Repro : Added a class with same name as an outer class and as an inner static class of some other parent class. This will throw a build time error since there are two typeadapters with same name.

Testing : Same as repro steps.

**4. Removed try/catch block for nested cases** : Since try/catch exception blocks decreases performance, we removed these blocks especially for nested cases. Given that the core philosophy of Stag is based on performance all the current try/catch blocks give is more debugging ability. 

Testing : More of a performance gain.

**5. Fixed IllegalStateException while writing** : We're able to repro this while writing nested contents using stag. This was fixed as follows

Previously, while writing, if the object to be written was null, the writer.beginObject() and endObject() were not called, instead the method was returned. With the new changes, writer.beginObject() is called before the null check for object. In case the object is null, the writer.endObject() is called and method is returned. 



