### PR TITLE
Support for Alternate Names if using @SerializedName annotation + Consistent Order while serializing/deserializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stag improves Gson performance by automatically generating reflection-less TypeA
 | dev    | [![Build Status](https://circleci.com/gh/vimeo/stag-java/tree/dev.svg?style=shield&circle-token=4d5dd11678a93587658d1677d0ef2b8c64b56574)](https://circleci.com/gh/vimeo/stag-java/tree/dev) |
 
 
-## Why Build Stag?
+## Why Build Stag ?
 
 Gson is the essential JSON parsing library. It greatly simplifies what can be the verbose and boilerplate-ridden process of parsing JSON into model objects. It does this by leveraging reflection. Unfortunately, using reflection can be slow (particularly on the Android OS).
 
@@ -70,7 +70,7 @@ buildscript {
 apply plugin: 'com.neenbedankt.android-apt'
 ```
 
-#### 3. Passing package name as an argument for the generated files (Optional)
+#### 3. Pass package name as an argument for the generated files (Optional)
 By default, the files will be in generated in `com.vimeo.sample.stag.generated` package. But, you can specify your own package for the generated files by passing it as an argument to the apt compiler.
 ```groovy
 apt {
@@ -80,61 +80,80 @@ apt {
 }
 ```
 
+## Features
+
+#### 1. Class Level Annotation
+
+Stag supports class level annotation `@UseStag` which processes all the fields for a particular class, which makes it easy to use and integrate.
+
+`@UseStag` has three different variants -
+
+    * @UseStag(UseStag.FIELD_OPTION_ALL) : Will serialize/de-serialize all member variables which are not static or transient
+
+    * @UseStag(UseStag.FIELD_OPTION_NONE) : Will skip serialization and deserialization for all member variables
+
+    * @UseStag(UseStag.FIELD_OPTION_SERIALIZED_NAME) : Will Serialize or Deserialize Fields only which are annotated with SerializedName or GsonAdapterKey(deprecated)
+
+#### 2. @SerializedName("") Support
+
+Similar to GSON, you can use @SerializedName annotation to provide a different JSON name to a member field. It also supports alternate name feature of the @SerializedName
+
+    @SerializedName("name') or @SerializedName(value = "name", alternate = {"name1", "name2"})
+
+#### 3. Cross Module Support
+
+Stag has the ability to cross reference TypeAdapters accross modules.
+
+#### 4. In parity with GSON
+
+Last but not the least, Stag is almost in parity with GSON.
+
 ## Stag Rules
 
-1. Make sure the member variables of your model class are not private (i.e. public, protected, or package-local visibility)
+1. Make sure the member variables of your model class are not private (should be public, protected, or package-local visibility)
 2. Make sure your model class is not private and has a zero argument non-private constructor
-3. Annotate each member variable you want populated
-    - `@GsonAdapterKey("json_key")`: populates the field using the JSON value with the specified key
-    - `@GsonAdapterKey`: populates the field using the JSON value with the key named the same as the member variable
-    - Use your favorite `@NonNull` annotation to tell Stag to throw an exception if the field is null while deserializing or while serializing the object.
-4. Register the `Stag.Factory` with Gson when you create your Gson instance: `Gson gson = new GsonBuilder().registerTypeAdapterFactory(new Stag.Factory()).create();`
-5. You're done!
+3. Annotate the classes with `@UseStag` annotation. This will process all the member variables of the class, which makes it easy to use.
+4. Use the @SerializedName("") annotation to give the variables a different JSON name. (similiar to GSON)
+5. Use your favorite `@NonNull` annotation to tell Stag to throw an exception if the field is null while deserializing or while serializing the object.
+6. Register the `Stag.Factory` with Gson when you create your Gson instance: `Gson gson = new GsonBuilder().registerTypeAdapterFactory(new Stag.Factory()).create();`
+7. You're done!
 
-## Supported Types
-
-- YES: All native types supported by Gson (boolean, double, int, long, float)
-- YES: String types
-- YES: ArrayList or any other List interfaces are supported
-- YES: HashMaps or any other Map interfaces are supported
-- YES: Complex data structures supported
-- YES: Enumerations (enums)
-
-Note : 
-- `@SerializedName("json_key")` annotations you might be using will be ignored.
+<b>NOTE</b> : @GsonAdapterKey has been deprecated and will be removed in future releases. It is advisable to migrate to @SerializedName and @UseStag annotations.   
 
 See the [example below](#example) or the [sample app](sample) to get more info on how to use Stag.
 
 ## Example
 
 ```java
+@UseStag
 public class Deer {
-    @GsonAdapterKey("name")
+    @SerializedName("name")
     String mName;    // mName = json value with key "name"
     
-    @GsonAdapterKey("species")
+    @SerializedName("species")
     String mSpecies; // mSpecies = json value with key "species"
     
-    @GsonAdapterKey("age")
+    @SerializedName("age")
     int mAge;        // mAge = json value with key "age"
     
-    @GsonAdapterKey("points")
+    @SerializedName("points")
     int mPoints;     // mPoints = json value with key "points"
     
-    @GsonAdapterKey("weight")
+    @SerializedName("weight")
     float mWeight;     // mWeight = json value with key "weight"
 }
 
+@UseStag
 public class Herd {
 
     @NonNull                    // add NonNull annotation to throw an exception if the field is null
-    @GsonAdapterKey
+    @SerializedName("data_list")
     ArrayList<Deer> data_list;  // data_list = json value with key "data_list"
     
-    @GsonAdapterKey
+    @SerializedName("data_list_copy")
     List<Deer> data_list_copy;  // data_list_copy = json value with key "data_list_copy"
     
-    @GsonAdapterKey
+    @SerializedName("data_map")
     Map<String, Deer> data_map;  // data_map = json value with key "data_map"
 }
 
@@ -159,8 +178,6 @@ MyParsingClass {
 ## Future Enhancements
 
 - Add an option to absorb parsing errors rather than crashing and halting parsing (default gson behavior)
-- Class level annotation so that you don't have to annotate each field
-- Support using `@SerializedName` annotation
 
 ## License
 `stag-java` is available under the MIT license. See the [LICENSE](LICENSE) file for more information.

--- a/sample-model/src/main/java/com/vimeo/sample_model/AlternateNameModel.java
+++ b/sample-model/src/main/java/com/vimeo/sample_model/AlternateNameModel.java
@@ -1,0 +1,14 @@
+package com.vimeo.sample_model;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class AlternateNameModel {
+
+    @SerializedName(value = "Nougat", alternate = {"Kitkat", "Lollipop"})
+    String mAndroidVersions;
+
+    @SerializedName(value = "7.0", alternate = {"4.0", "5.0"})
+    String mAndroidNameVersions;
+}

--- a/sample-model/src/main/java/com/vimeo/sample_model/AlternateNameModel1.java
+++ b/sample-model/src/main/java/com/vimeo/sample_model/AlternateNameModel1.java
@@ -1,0 +1,13 @@
+package com.vimeo.sample_model;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public enum AlternateNameModel1 {
+    @SerializedName(value = "7.0", alternate = {"4.0", "5.0"})
+    ANDROID_VERSION,
+
+    @SerializedName(value = "Nougat", alternate = {"Kitkat", "Lollipop"})
+    ANDROID_VERSION_NAME
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
@@ -29,6 +29,7 @@ import com.squareup.javapoet.TypeSpec;
 import com.vimeo.stag.GsonAdapterKey;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.lang.model.element.Element;
 
@@ -54,6 +55,14 @@ public abstract class AdapterGenerator {
             name = element.getSimpleName().toString();
         }
         return name;
+    }
+
+    /**
+     * Returns the alternate name for the {@link Element}
+     */
+    @Nullable
+    static String[] getAlternateJsonNames(@NotNull Element element) {
+        return (null != element.getAnnotation(SerializedName.class)) ? element.getAnnotation(SerializedName.class).alternate() : null;
     }
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/EnumTypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/EnumTypeAdapterGenerator.java
@@ -125,6 +125,13 @@ public class EnumTypeAdapterGenerator extends AdapterGenerator {
                 String name = getJsonName(enclosingElement);
                 nameToConstant.put(name, enclosingElement);
                 constantToName.put(enclosingElement, name);
+
+                String[] alternateJsonNames = getAlternateJsonNames(enclosingElement);
+                if (alternateJsonNames != null && alternateJsonNames.length > 0) {
+                    for (String alternate : alternateJsonNames) {
+                        nameToConstant.put(alternate, enclosingElement);
+                    }
+                }
             }
         }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -225,8 +225,16 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             final String variableName = element.getKey().getSimpleName().toString();
             final TypeMirror elementValue = element.getValue();
 
-            builder.addCode("\t\t\tcase \"" + name + "\":\n" +
-                    "\t\t\t\tobject." + variableName + " = " + adapterFieldInfo.getAdapterAccessor(elementValue) + ".read(reader);");
+            builder.addCode("\t\t\tcase \"" + name + "\":\n");
+
+            String[] alternateJsonNames = getAlternateJsonNames(element.getKey());
+            if (alternateJsonNames != null && alternateJsonNames.length > 0) {
+                for (String alternateJsonName : alternateJsonNames) {
+                    builder.addCode("\t\t\tcase \"" + alternateJsonName + "\":\n");
+                }
+            }
+
+            builder.addCode("\t\t\t\tobject." + variableName + " = " + adapterFieldInfo.getAdapterAccessor(elementValue) + ".read(reader);");
 
             builder.addCode("\n\t\t\t\tbreak;\n");
             runIfAnnotationSupported(element.getKey().getAnnotationMirrors(), new Runnable() {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -24,7 +24,6 @@
 package com.vimeo.stag.processor.generators.model;
 
 import com.google.gson.annotations.SerializedName;
-import com.sun.org.apache.bcel.internal.generic.Type;
 import com.vimeo.stag.GsonAdapterKey;
 import com.vimeo.stag.UseStag;
 import com.vimeo.stag.processor.StagProcessor;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -286,11 +286,11 @@ public final class TypeUtils {
      * @param members           the member variable map of the field (Element) to their concrete
      *                          type (TypeMirror). This should be retrieved by calling getConcreteMembers
      *                          on the inherited class.
-     * @return returns a map of the member variables mapped to their concrete types for the concrete
-     * inherited class.
+     * @return returns a linked has map of the member variables mapped to their concrete types for the concrete
+     * inherited class. (to maintain the ordering)
      */
     @NotNull
-    public static Map<Element, TypeMirror> getConcreteMembers(@NotNull TypeMirror concreteInherited,
+    public static LinkedHashMap<Element, TypeMirror> getConcreteMembers(@NotNull TypeMirror concreteInherited,
                                                               @NotNull Element genericInherited,
                                                               @NotNull Map<Element, TypeMirror> members) {
 
@@ -299,7 +299,7 @@ public final class TypeUtils {
         List<? extends TypeMirror> concreteTypes = getParameterizedTypes(concreteInherited);
         List<? extends TypeMirror> inheritedTypes = getParameterizedTypes(genericInherited);
 
-        Map<Element, TypeMirror> map = new HashMap<>();
+        LinkedHashMap<Element, TypeMirror> map = new LinkedHashMap<>();
 
         for (Entry<Element, TypeMirror> member : members.entrySet()) {
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -286,7 +286,7 @@ public final class TypeUtils {
      * @param members           the member variable map of the field (Element) to their concrete
      *                          type (TypeMirror). This should be retrieved by calling getConcreteMembers
      *                          on the inherited class.
-     * @return returns a linked has map of the member variables mapped to their concrete types for the concrete
+     * @return returns a LinkedHashMap of the member variables mapped to their concrete types for the concrete
      * inherited class. (to maintain the ordering)
      */
     @NotNull

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
@@ -139,7 +139,7 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
 
         assertNotNull(genericType);
 
-        Map<Element, TypeMirror> members =
+        LinkedHashMap<Element, TypeMirror> members =
                 TypeUtils.getConcreteMembers(concreteType, types.asElement(genericType), genericMembers);
 
 


### PR DESCRIPTION
Changes 

1. Support for Alternate Names if using @SerializedName annotation : 

![screen shot 2017-01-12 at 12 28 37 pm](https://cloud.githubusercontent.com/assets/16556984/21881163/c4bc8d8a-d8c8-11e6-9b00-39f8e32764f1.png)

2. Consistent Order while Serializing / Deserializing