### PR TITLE
Parsing using TypeAdapters

### DIFF
--- a/sample/src/main/java/com/vimeo/sample/network/NetworkRequest.java
+++ b/sample/src/main/java/com/vimeo/sample/network/NetworkRequest.java
@@ -34,10 +34,14 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.JsonTreeReader;
+import com.google.gson.stream.JsonReader;
 import com.vimeo.sample.model.DateParser;
 import com.vimeo.sample.model.Video;
 import com.vimeo.sample.model.VideoList;
 import com.vimeo.sample.stag.generated.Stag;
+import com.vimeo.stag.KnownTypeAdapters;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -116,16 +120,17 @@ public final class NetworkRequest {
                     builder.append(line);
                 }
 
+                Stag.Factory factory = new Stag.Factory();
                 Gson gson = new GsonBuilder().registerTypeAdapter(Date.class, new DateParser())
-                        .registerTypeAdapterFactory(new Stag.Factory())
+                        .registerTypeAdapterFactory(factory)
                         .create();
 
                 JsonObject jsonObject = new JsonParser().parse(builder.toString()).getAsJsonObject();
 
+                TypeAdapter<VideoList> videoListTypeAdapter = factory.getVideoList$TypeAdapter(gson);
                 long time = System.currentTimeMillis();
 
-                videos.addAll(gson.fromJson(jsonObject, VideoList.class).data);
-
+                videos.addAll(videoListTypeAdapter.fromJsonTree(jsonObject).data);
                 Log.d(TAG, "Time elapsed while parsing: " + (System.currentTimeMillis() - time) + " ms");
 
             } catch (IOException e) {


### PR DESCRIPTION
Since gson.fromJson("string", .class) internally uses reflection to figure out the type and to call it's corresponding type adapter by iterating through the factory, we can actually avoid this reflection by directly providing the type adapter, instead of asking the gson. 

<img width="713" alt="screen shot 2017-01-13 at 11 24 14 pm" src="https://cloud.githubusercontent.com/assets/16556984/21939807/6f0e9ef8-d9e7-11e6-89bd-898c5b1d3cbb.png">

We already have the type adapter for VideoList.class, we can use its type adapter, and serialize/deserialize (this will avoid creation of TypeToken of VideoList.class)

**We ran a profiling (5 iterations) for the same, sharing the results :** 

**Earlier : (avg 13.6 ms)**

Time elapsed while parsing: 12 ms
Time elapsed while parsing: 15 ms
Time elapsed while parsing: 15 ms
Time elapsed while parsing: 13 ms
Time elapsed while parsing: 13 ms

**Now : (avg 10 ms)**

Time elapsed while parsing: 9 ms
Time elapsed while parsing: 10 ms
Time elapsed while parsing: 13 ms
Time elapsed while parsing: 10 ms
Time elapsed while parsing: 8 ms

We were able to shave off around 4-5 ms in each run. Overall, it gave us 26.4 % improvement in the parsing time.