### PR TITLE
Type adapter compilation safety

### DIFF
--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -26,6 +26,7 @@ package com.vimeo.stag.processor;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.JavaFile;
 import com.vimeo.stag.GsonAdapterKey;
+import com.vimeo.stag.KnownTypeAdapters;
 import com.vimeo.stag.UseStag;
 import com.vimeo.stag.processor.generators.AdapterGenerator;
 import com.vimeo.stag.processor.generators.EnumTypeAdapterGenerator;
@@ -38,7 +39,10 @@ import com.vimeo.stag.processor.utils.DebugLog;
 import com.vimeo.stag.processor.utils.ElementUtils;
 import com.vimeo.stag.processor.utils.FileGenUtils;
 import com.vimeo.stag.processor.utils.KnownTypeAdapterFactoriesUtils;
+import com.vimeo.stag.processor.utils.KnownTypeAdapterUtils;
 import com.vimeo.stag.processor.utils.TypeUtils;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -46,6 +50,7 @@ import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -83,21 +88,32 @@ public final class StagProcessor extends AbstractProcessor {
         return SourceVersion.RELEASE_7;
     }
 
+    private static boolean getDebugBoolean(@NotNull ProcessingEnvironment processingEnvironment) {
+        String debugString = processingEnvironment.getOptions().get(OPTION_DEBUG);
+        if (debugString != null) {
+            return Boolean.valueOf(debugString);
+        }
+        return false;
+    }
+
+    @NotNull
+    private static String getOptionalPackageName(@NotNull ProcessingEnvironment processingEnvironment) {
+        String packageName = processingEnvironment.getOptions().get(OPTION_PACKAGE_NAME);
+        if (packageName == null || packageName.isEmpty()) {
+            packageName = DEFAULT_GENERATED_PACKAGE_NAME;
+        }
+        return packageName;
+    }
+
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         if (mHasBeenProcessed) {
             return true;
         }
 
-        String packageName = processingEnv.getOptions().get(OPTION_PACKAGE_NAME);
-        if (packageName == null || packageName.isEmpty()) {
-            packageName = DEFAULT_GENERATED_PACKAGE_NAME;
-        }
+        DEBUG = getDebugBoolean(processingEnv);
 
-        String debugString = processingEnv.getOptions().get(OPTION_DEBUG);
-        if (debugString != null) {
-            DEBUG = Boolean.valueOf(debugString);
-        }
+        String packageName = getOptionalPackageName(processingEnv);
 
         String stagFactoryGeneratedName = StagGenerator.getGeneratedFactoryClassAndPackage(packageName);
         TypeUtils.initialize(processingEnv.getTypeUtils());
@@ -139,24 +155,24 @@ public final class StagProcessor extends AbstractProcessor {
             }
 
             StagGenerator adapterGenerator = new StagGenerator(packageName, filer, mSupportedTypes,
-                                                               SupportedTypesModel.getInstance()
-                                                                       .getExternalSupportedAdapters());
+                    SupportedTypesModel.getInstance()
+                            .getExternalSupportedAdapters());
             TypeTokenConstantsGenerator typeTokenConstantsGenerator =
                     new TypeTokenConstantsGenerator(filer, packageName);
 
             Set<Element> list = SupportedTypesModel.getInstance().getSupportedElements();
             for (Element element : list) {
                 if ((TypeUtils.isConcreteType(element) || TypeUtils.isParameterizedType(element)) &&
-                    !TypeUtils.isAbstract(element)) {
+                        !TypeUtils.isAbstract(element)) {
                     ClassInfo classInfo = new ClassInfo(element.asType());
                     AdapterGenerator independentAdapter =
                             element.getKind() == ElementKind.ENUM ? new EnumTypeAdapterGenerator(classInfo,
-                                                                                                 element) : new TypeAdapterGenerator(
+                                    element) : new TypeAdapterGenerator(
                                     classInfo);
                     JavaFile javaFile = JavaFile.builder(classInfo.getPackageName(),
-                                                         independentAdapter.getTypeAdapterSpec(
-                                                                 typeTokenConstantsGenerator,
-                                                                 adapterGenerator)).build();
+                            independentAdapter.getTypeAdapterSpec(
+                                    typeTokenConstantsGenerator,
+                                    adapterGenerator)).build();
                     FileGenUtils.writeToFile(javaFile, filer);
                 }
             }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -34,6 +34,10 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import com.vimeo.stag.KnownTypeAdapters.ArrayTypeAdapter;
+import com.vimeo.stag.KnownTypeAdapters.ListTypeAdapter;
+import com.vimeo.stag.KnownTypeAdapters.MapTypeAdapter;
+import com.vimeo.stag.KnownTypeAdapters.ObjectTypeAdapter;
 import com.vimeo.stag.processor.generators.model.AnnotatedClass;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
 import com.vimeo.stag.processor.generators.model.SupportedTypesModel;
@@ -150,7 +154,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                             getAdapterAccessor(valueTypeMirror, adapterBuilder, constructorBuilder,
                                                typeTokenConstantsGenerator, typeVarsMap, stagGenerator,
                                                adapterFieldInfo);
-                    result = "new com.vimeo.stag.KnownTypeAdapters.MapTypeAdapter<" +
+                    result = "new " + TypeUtils.className(MapTypeAdapter.class) + "<" +
                              keyTypeMirror.toString() + "," + valueTypeMirror.toString() + "," +
                              fieldType.toString() + ">(" + keyAdapterAccessor + " ," + valueAdapterAccessor +
                              ", " + KnownTypeAdapterUtils.getMapInstantiator(fieldType) + ")";
@@ -163,7 +167,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                             getAdapterAccessor(valueTypeMirror, adapterBuilder, constructorBuilder,
                                                typeTokenConstantsGenerator, typeVarsMap, stagGenerator,
                                                adapterFieldInfo);
-                    result = "new com.vimeo.stag.KnownTypeAdapters.ListTypeAdapter<" +
+                    result = "new " + TypeUtils.className(ListTypeAdapter.class) + "<" +
                              valueTypeMirror.toString() + "," + fieldType.toString() + ">(" +
                              valueAdapterAccessor + ", " +
                              KnownTypeAdapterUtils.getListInstantiator(fieldType) + ")";
@@ -355,7 +359,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                                                adapterFieldInfo);
                     String nativeArrayInstantiator =
                             KnownTypeAdapterUtils.getNativeArrayInstantiator(arrayInnerType);
-                    String adapterCode = "new com.vimeo.stag.KnownTypeAdapters.ArrayTypeAdapter<" +
+                    String adapterCode = "new " + TypeUtils.className(ArrayTypeAdapter.class) + "<" +
                                          arrayInnerType.toString() + ">" +
                                          "(" + adapterAccessor + ", " + nativeArrayInstantiator + ")";
                     if (arrayType.getComponentType().getKind() != TypeKind.TYPEVAR &&
@@ -383,7 +387,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
                 String listInstantiator = KnownTypeAdapterUtils.getListInstantiator(fieldType);
                 String adapterCode =
-                        "new com.vimeo.stag.KnownTypeAdapters.ListTypeAdapter<" + param.toString() + "," +
+                        "new " + TypeUtils.className(ListTypeAdapter.class) + "<" + param.toString() + "," +
                         fieldType.toString() + ">" +
                         "(" + paramAdapterAccessor + ", " + listInstantiator + ")";
                 if (declaredType.getKind() != TypeKind.TYPEVAR &&
@@ -418,12 +422,13 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                     arguments = "<" + keyType.toString() + ", " + valueType.toString() + ", " +
                                 fieldType.toString() + ">";
                 } else {
-                    //If the map does not have any type arguments, use Object as type params in this case
-                    keyAdapterAccessor = "new com.vimeo.stag.KnownTypeAdapters.ObjectTypeAdapter(mGson)";
-                    valueAdapterAccessor = "new com.vimeo.stag.KnownTypeAdapters.ObjectTypeAdapter(mGson)";
+                    // If the map does not have any type arguments, use Object as type params in this case
+                    String objectTypeAdapter = TypeUtils.className(ObjectTypeAdapter.class);
+                    keyAdapterAccessor = "new " + objectTypeAdapter + "(mGson)";
+                    valueAdapterAccessor = "new " + objectTypeAdapter + "(mGson)";
                 }
 
-                String adapterCode = "new com.vimeo.stag.KnownTypeAdapters.MapTypeAdapter" + arguments +
+                String adapterCode = "new " + TypeUtils.className(MapTypeAdapter.class) + arguments +
                                      "(" + keyAdapterAccessor + ", " + valueAdapterAccessor + ", " +
                                      mapInstantiator + ")";
                 if (declaredType.getKind() != TypeKind.TYPEVAR &&
@@ -439,7 +444,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                  * If the fieldType is Object, use ObjectTypeAdapter
                  */
                 sGsonVariableUsed = true;
-                String adapterCode = "new com.vimeo.stag.KnownTypeAdapters.ObjectTypeAdapter(mGson)";
+                String adapterCode = "new " + TypeUtils.className(ObjectTypeAdapter.class) + "(mGson)";
                 String getterName = stagGenerator.addFieldForKnownType(fieldType,
                                                                        adapterCode.replaceAll("mStagFactory.",
                                                                                               "")

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -40,13 +40,13 @@ public final class KnownTypeAdapterUtils {
     private static final HashMap<String, String> KNOWN_TYPE_ADAPTERS = new HashMap<>();
 
     @NotNull
-    private static final HashMap<String, String> SUPPORTED_COLLECTION_INFO = new HashMap<>();
+    private static final HashMap<String, String> SUPPORTED_COLLECTION_INSTANTIATORS = new HashMap<>();
 
     @NotNull
-    private static final HashMap<String, String> SUPPORTED_MAP_INFO = new HashMap<>();
+    private static final HashMap<String, String> SUPPORTED_MAP_INSTANTIATORS = new HashMap<>();
 
     @NotNull
-    private static final HashMap<String, String> SUPPORTED_PRIMITIVE_ARRAY = new HashMap<>();
+    private static final HashMap<String, String> KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS = new HashMap<>();
 
     static {
         KNOWN_TYPE_ADAPTERS.put(BitSet.class.getName(), typeAdapters(TypeAdapters.BIT_SET));
@@ -81,23 +81,23 @@ public final class KnownTypeAdapterUtils {
         KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_PRIMITIVE));
         KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_NULL));
 
-        SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), className(KnownTypeAdapters.ArrayListInstantiator.class));
-        SUPPORTED_COLLECTION_INFO.put(List.class.getName(), className(KnownTypeAdapters.ListInstantiator.class));
-        SUPPORTED_COLLECTION_INFO.put(Collection.class.getName(), className(KnownTypeAdapters.CollectionInstantiator.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(int[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveIntegerArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(long[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveLongArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(double[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveDoubleArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(short[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveShortArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(char[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveCharArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(float[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveFloatArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(boolean[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveBooleanArrayAdapter.class));
+        KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.put(byte[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveByteArrayAdapter.class));
 
-        SUPPORTED_MAP_INFO.put(Map.class.getName(), className(KnownTypeAdapters.MapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(HashMap.class.getName(), className(KnownTypeAdapters.HashMapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(LinkedHashMap.class.getName(), className(KnownTypeAdapters.LinkedHashMapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(ConcurrentHashMap.class.getName(), className(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
+        SUPPORTED_COLLECTION_INSTANTIATORS.put(ArrayList.class.getName(), className(KnownTypeAdapters.ArrayListInstantiator.class));
+        SUPPORTED_COLLECTION_INSTANTIATORS.put(List.class.getName(), className(KnownTypeAdapters.ListInstantiator.class));
+        SUPPORTED_COLLECTION_INSTANTIATORS.put(Collection.class.getName(), className(KnownTypeAdapters.CollectionInstantiator.class));
 
-        SUPPORTED_PRIMITIVE_ARRAY.put(int[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveIntegerArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(long[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveLongArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(double[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveDoubleArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(short[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveShortArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(char[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveCharArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(float[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveFloatArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(boolean[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveBooleanArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(byte[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveByteArrayAdapter.class));
+        SUPPORTED_MAP_INSTANTIATORS.put(Map.class.getName(), className(KnownTypeAdapters.MapInstantiator.class));
+        SUPPORTED_MAP_INSTANTIATORS.put(HashMap.class.getName(), className(KnownTypeAdapters.HashMapInstantiator.class));
+        SUPPORTED_MAP_INSTANTIATORS.put(LinkedHashMap.class.getName(), className(KnownTypeAdapters.LinkedHashMapInstantiator.class));
+        SUPPORTED_MAP_INSTANTIATORS.put(ConcurrentHashMap.class.getName(), className(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
     }
 
     @NotNull
@@ -153,7 +153,7 @@ public final class KnownTypeAdapterUtils {
                                !declaredType.getTypeArguments().isEmpty() ? declaredType.getTypeArguments()
                 .get(0) : null;
         String postFix = valueType != null ? "<" + valueType.toString() + ">()" : "()";
-        return "new " + SUPPORTED_COLLECTION_INFO.get(outerClassType) + postFix;
+        return "new " + SUPPORTED_COLLECTION_INSTANTIATORS.get(outerClassType) + postFix;
     }
 
     /**
@@ -175,7 +175,7 @@ public final class KnownTypeAdapterUtils {
         String postFix = keyType != null && paramType != null ?
                 "<" + keyType.toString() + ", " + paramType.toString() + ">()" : "()";
 
-        String instantiator = SUPPORTED_MAP_INFO.get(outerClassType);
+        String instantiator = SUPPORTED_MAP_INSTANTIATORS.get(outerClassType);
 
         if (instantiator != null) {
             return "new " + instantiator + postFix;
@@ -217,6 +217,6 @@ public final class KnownTypeAdapterUtils {
     @Nullable
     public static String getNativePrimitiveArrayTypeAdapter(@NotNull TypeMirror typeMirror) {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
-        return SUPPORTED_PRIMITIVE_ARRAY.get(outerClassType);
+        return KNOWN_PRIMITIVE_ARRAY_TYPE_ADAPTERS.get(outerClassType);
     }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -150,7 +150,7 @@ public final class KnownTypeAdapterUtils {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
         DeclaredType declaredType = typeMirror instanceof DeclaredType ? (DeclaredType) typeMirror : null;
         TypeMirror valueType = declaredType != null && declaredType.getTypeArguments() != null &&
-                !declaredType.getTypeArguments().isEmpty() ? declaredType.getTypeArguments()
+                               !declaredType.getTypeArguments().isEmpty() ? declaredType.getTypeArguments()
                 .get(0) : null;
         String postFix = valueType != null ? "<" + valueType.toString() + ">()" : "()";
         return "new " + SUPPORTED_COLLECTION_INFO.get(outerClassType) + postFix;
@@ -167,10 +167,10 @@ public final class KnownTypeAdapterUtils {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
         DeclaredType declaredType = typeMirror instanceof DeclaredType ? (DeclaredType) typeMirror : null;
         TypeMirror keyType = declaredType != null && declaredType.getTypeArguments() != null &&
-                declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
+                             declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
                 .get(0) : null;
         TypeMirror paramType = declaredType != null && declaredType.getTypeArguments() != null &&
-                declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
+                               declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
                 .get(1) : null;
         String postFix = keyType != null && paramType != null ?
                 "<" + keyType.toString() + ", " + paramType.toString() + ">()" : "()";
@@ -182,7 +182,8 @@ public final class KnownTypeAdapterUtils {
         } else {
             String params = keyType != null && paramType != null ?
                     "<" + keyType.toString() + ", " + paramType.toString() + ">" : "";
-            return "new " + className(com.google.gson.internal.ObjectConstructor.class) + "<" + outerClassType + params + ">() " +
+            return "new " + className(com.google.gson.internal.ObjectConstructor.class) + "<" +
+                   outerClassType + params + ">() " +
                    "{ " +
                    "\n@Override " +
                    "\npublic " + outerClassType + params + " construct() {" +
@@ -201,9 +202,10 @@ public final class KnownTypeAdapterUtils {
     @Nullable
     public static String getNativeArrayInstantiator(@NotNull TypeMirror typeMirror) {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
-        return "new com.vimeo.stag.KnownTypeAdapters.PrimitiveArrayConstructor<" + outerClassType +
-                ">(){ @Override public " + outerClassType + "[] construct(int size){ return new " +
-                outerClassType + "[size]; } }";
+        return "new " + className(com.vimeo.stag.KnownTypeAdapters.PrimitiveArrayConstructor.class) + "<" +
+               outerClassType +
+               ">(){ @Override public " + outerClassType + "[] construct(int size){ return new " +
+               outerClassType + "[size]; } }";
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -5,10 +5,13 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.vimeo.stag.KnownTypeAdapters;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -40,54 +43,92 @@ public final class KnownTypeAdapterUtils {
     private static final HashMap<String, String> SUPPORTED_COLLECTION_INFO = new HashMap<>();
 
     @NotNull
+    private static final HashMap<String, String> SUPPORTED_MAP_INFO = new HashMap<>();
+
+    @NotNull
     private static final HashMap<String, String> SUPPORTED_PRIMITIVE_ARRAY = new HashMap<>();
 
     static {
-        KNOWN_TYPE_ADAPTERS.put(BitSet.class.getName(), "com.google.gson.internal.bind.TypeAdapters.BIT_SET");
-        KNOWN_TYPE_ADAPTERS.put(Boolean.class.getName(), "com.google.gson.internal.bind.TypeAdapters.BOOLEAN");
-        KNOWN_TYPE_ADAPTERS.put(boolean.class.getName(), "com.google.gson.internal.bind.TypeAdapters.BOOLEAN");
-        KNOWN_TYPE_ADAPTERS.put(Byte.class.getName(), "com.vimeo.stag.KnownTypeAdapters.BYTE");
-        KNOWN_TYPE_ADAPTERS.put(byte.class.getName(), "com.vimeo.stag.KnownTypeAdapters.BYTE");
-        KNOWN_TYPE_ADAPTERS.put(Short.class.getName(), "com.vimeo.stag.KnownTypeAdapters.SHORT");
-        KNOWN_TYPE_ADAPTERS.put(short.class.getName(), "com.vimeo.stag.KnownTypeAdapters.SHORT");
-        KNOWN_TYPE_ADAPTERS.put(Integer.class.getName(), "com.vimeo.stag.KnownTypeAdapters.INTEGER");
-        KNOWN_TYPE_ADAPTERS.put(int.class.getName(), "com.vimeo.stag.KnownTypeAdapters.INTEGER");
-        KNOWN_TYPE_ADAPTERS.put(Long.class.getName(), "com.vimeo.stag.KnownTypeAdapters.LONG");
-        KNOWN_TYPE_ADAPTERS.put(long.class.getName(), "com.vimeo.stag.KnownTypeAdapters.LONG");
-        KNOWN_TYPE_ADAPTERS.put(Float.class.getName(), "com.vimeo.stag.KnownTypeAdapters.FLOAT");
-        KNOWN_TYPE_ADAPTERS.put(float.class.getName(), "com.vimeo.stag.KnownTypeAdapters.FLOAT");
-        KNOWN_TYPE_ADAPTERS.put(Double.class.getName(), "com.vimeo.stag.KnownTypeAdapters.DOUBLE");
-        KNOWN_TYPE_ADAPTERS.put(double.class.getName(), "com.vimeo.stag.KnownTypeAdapters.DOUBLE");
-        KNOWN_TYPE_ADAPTERS.put(Number.class.getName(), "com.google.gson.internal.bind.TypeAdapters.NUMBER");
-        KNOWN_TYPE_ADAPTERS.put(Character.class.getName(), "com.google.gson.internal.bind.TypeAdapters.CHARACTER");
-        KNOWN_TYPE_ADAPTERS.put(char.class.getName(), "com.google.gson.internal.bind.TypeAdapters.CHARACTER");
-        KNOWN_TYPE_ADAPTERS.put(String.class.getName(), "com.google.gson.internal.bind.TypeAdapters.STRING");
-        KNOWN_TYPE_ADAPTERS.put(BigDecimal.class.getName(), "com.google.gson.internal.bind.TypeAdapters.BIG_DECIMAL");
-        KNOWN_TYPE_ADAPTERS.put(BigInteger.class.getName(), "com.google.gson.internal.bind.TypeAdapters.BIG_INTEGER");
-        KNOWN_TYPE_ADAPTERS.put(AtomicBoolean.class.getName(), "com.google.gson.internal.bind.TypeAdapters.ATOMIC_BOOLEAN");
-        KNOWN_TYPE_ADAPTERS.put(AtomicInteger.class.getName(), "com.google.gson.internal.bind.TypeAdapters.ATOMIC_INTEGER");
-        KNOWN_TYPE_ADAPTERS.put(AtomicIntegerArray.class.getName(), "com.google.gson.internal.bind.TypeAdapters.ATOMIC_INTEGER_ARRAY");
-        KNOWN_TYPE_ADAPTERS.put(Currency.class.getName(), "com.google.gson.internal.bind.TypeAdapters.CURRENCY");
-        KNOWN_TYPE_ADAPTERS.put(Calendar.class.getName(), "com.google.gson.internal.bind.TypeAdapters.CALENDAR");
-        KNOWN_TYPE_ADAPTERS.put(Number.class.getName(), "com.google.gson.internal.bind.TypeAdapters.NUMBER");
-        KNOWN_TYPE_ADAPTERS.put(JsonElement.class.getName(), "com.vimeo.stag.KnownTypeAdapters.JSON_ELEMENT_TYPE_ADAPTER");
-        KNOWN_TYPE_ADAPTERS.put(JsonObject.class.getName(), "com.vimeo.stag.KnownTypeAdapters.JSON_OBJECT_TYPE_ADAPTER");
-        KNOWN_TYPE_ADAPTERS.put(JsonArray.class.getName(), "com.vimeo.stag.KnownTypeAdapters.JSON_ARRAY_TYPE_ADAPTER");
-        KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), "com.vimeo.stag.KnownTypeAdapters.JSON_PRIMITIVE_TYPE_ADAPTER");
-        KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), "com.vimeo.stag.KnownTypeAdapters.JSON_NULL_TYPE_ADAPTER");
+        KNOWN_TYPE_ADAPTERS.put(BitSet.class.getName(), typeAdapters(TypeAdapters.BIT_SET));
+        KNOWN_TYPE_ADAPTERS.put(Boolean.class.getName(), typeAdapters(TypeAdapters.BOOLEAN));
+        KNOWN_TYPE_ADAPTERS.put(boolean.class.getName(), typeAdapters(TypeAdapters.BOOLEAN));
+        KNOWN_TYPE_ADAPTERS.put(Byte.class.getName(), knownTypeAdapters(KnownTypeAdapters.BYTE));
+        KNOWN_TYPE_ADAPTERS.put(byte.class.getName(), knownTypeAdapters(KnownTypeAdapters.BYTE));
+        KNOWN_TYPE_ADAPTERS.put(Short.class.getName(), knownTypeAdapters(KnownTypeAdapters.SHORT));
+        KNOWN_TYPE_ADAPTERS.put(short.class.getName(), knownTypeAdapters(KnownTypeAdapters.SHORT));
+        KNOWN_TYPE_ADAPTERS.put(Integer.class.getName(), knownTypeAdapters(KnownTypeAdapters.INTEGER));
+        KNOWN_TYPE_ADAPTERS.put(int.class.getName(), knownTypeAdapters(KnownTypeAdapters.INTEGER));
+        KNOWN_TYPE_ADAPTERS.put(Long.class.getName(), knownTypeAdapters(KnownTypeAdapters.LONG));
+        KNOWN_TYPE_ADAPTERS.put(long.class.getName(), knownTypeAdapters(KnownTypeAdapters.LONG));
+        KNOWN_TYPE_ADAPTERS.put(Float.class.getName(), knownTypeAdapters(KnownTypeAdapters.FLOAT));
+        KNOWN_TYPE_ADAPTERS.put(float.class.getName(), knownTypeAdapters(KnownTypeAdapters.FLOAT));
+        KNOWN_TYPE_ADAPTERS.put(Double.class.getName(), knownTypeAdapters(KnownTypeAdapters.DOUBLE));
+        KNOWN_TYPE_ADAPTERS.put(double.class.getName(), knownTypeAdapters(KnownTypeAdapters.DOUBLE));
+        KNOWN_TYPE_ADAPTERS.put(Number.class.getName(), typeAdapters(TypeAdapters.NUMBER));
+        KNOWN_TYPE_ADAPTERS.put(Character.class.getName(), typeAdapters(TypeAdapters.CHARACTER));
+        KNOWN_TYPE_ADAPTERS.put(char.class.getName(), typeAdapters(TypeAdapters.CHARACTER));
+        KNOWN_TYPE_ADAPTERS.put(String.class.getName(), typeAdapters(TypeAdapters.STRING));
+        KNOWN_TYPE_ADAPTERS.put(BigDecimal.class.getName(), typeAdapters(TypeAdapters.BIG_DECIMAL));
+        KNOWN_TYPE_ADAPTERS.put(BigInteger.class.getName(), typeAdapters(TypeAdapters.BIG_INTEGER));
+        KNOWN_TYPE_ADAPTERS.put(AtomicBoolean.class.getName(), typeAdapters(TypeAdapters.ATOMIC_BOOLEAN));
+        KNOWN_TYPE_ADAPTERS.put(AtomicInteger.class.getName(), typeAdapters(TypeAdapters.ATOMIC_INTEGER));
+        KNOWN_TYPE_ADAPTERS.put(AtomicIntegerArray.class.getName(), typeAdapters(TypeAdapters.ATOMIC_INTEGER_ARRAY));
+        KNOWN_TYPE_ADAPTERS.put(Currency.class.getName(), typeAdapters(TypeAdapters.CURRENCY));
+        KNOWN_TYPE_ADAPTERS.put(Calendar.class.getName(), typeAdapters(TypeAdapters.CALENDAR));
+        KNOWN_TYPE_ADAPTERS.put(JsonElement.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ELEMENT_TYPE_ADAPTER));
+        KNOWN_TYPE_ADAPTERS.put(JsonObject.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_OBJECT_TYPE_ADAPTER));
+        KNOWN_TYPE_ADAPTERS.put(JsonArray.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ARRAY_TYPE_ADAPTER));
+        KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_PRIMITIVE_TYPE_ADAPTER));
+        KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_NULL_TYPE_ADAPTER));
 
-        SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), "com.vimeo.stag.KnownTypeAdapters.ArrayListInstantiator");
-        SUPPORTED_COLLECTION_INFO.put(List.class.getName(), "com.vimeo.stag.KnownTypeAdapters.ListInstantiator");
-        SUPPORTED_COLLECTION_INFO.put(Collection.class.getName(), "com.vimeo.stag.KnownTypeAdapters.CollectionInstantiator");
+        SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), sanitizeClassName(KnownTypeAdapters.ArrayListInstantiator.class));
+        SUPPORTED_COLLECTION_INFO.put(List.class.getName(), sanitizeClassName(KnownTypeAdapters.ListInstantiator.class));
+        SUPPORTED_COLLECTION_INFO.put(Collection.class.getName(), sanitizeClassName(KnownTypeAdapters.CollectionInstantiator.class));
 
-        SUPPORTED_PRIMITIVE_ARRAY.put(int[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveIntegerArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(long[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveLongArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(double[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveDoubleArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(short[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveShortArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(char[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveCharArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(float[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveFloatArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(boolean[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveBooleanArrayAdapter");
-        SUPPORTED_PRIMITIVE_ARRAY.put(byte[].class.getSimpleName(), "com.vimeo.stag.KnownTypeAdapters.PrimitiveByteArrayAdapter");
+        SUPPORTED_MAP_INFO.put(Map.class.getName(), sanitizeClassName(KnownTypeAdapters.MapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(HashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.HashMapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(LinkedHashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.LinkedHashMapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(ConcurrentHashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
+
+        SUPPORTED_PRIMITIVE_ARRAY.put(int[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveIntegerArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(long[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveLongArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(double[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveDoubleArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(short[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveShortArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(char[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveCharArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(float[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveFloatArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(boolean[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveBooleanArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(byte[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveByteArrayAdapter.class));
+    }
+
+    @NotNull
+    private static String sanitizeClassName(@NotNull Class clazz) {
+        return clazz.getName().replace('$', '.');
+    }
+
+    @NotNull
+    private static String typeAdapters(@NotNull Object object) {
+        return fieldToString(TypeAdapters.class, object);
+    }
+
+    @NotNull
+    private static String knownTypeAdapters(@NotNull Object object) {
+        return fieldToString(KnownTypeAdapters.class, object);
+    }
+
+    @NotNull
+    private static String fieldToString(@NotNull Class clazz, @NotNull Object object) {
+        Field[] fields = clazz.getFields();
+        for (Field field : fields) {
+            try {
+                if (field.get(null) == object) {
+                    return clazz.getName() + '.' + field.getName();
+                }
+            } catch (IllegalAccessException e) {
+                DebugLog.log(e.getMessage());
+            }
+        }
+
+        throw new IllegalStateException("Unable to find field: " + clazz.getName());
     }
 
     private KnownTypeAdapterUtils() {
@@ -109,7 +150,7 @@ public final class KnownTypeAdapterUtils {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
         DeclaredType declaredType = typeMirror instanceof DeclaredType ? (DeclaredType) typeMirror : null;
         TypeMirror valueType = declaredType != null && declaredType.getTypeArguments() != null &&
-                               !declaredType.getTypeArguments().isEmpty() ? declaredType.getTypeArguments()
+                !declaredType.getTypeArguments().isEmpty() ? declaredType.getTypeArguments()
                 .get(0) : null;
         String postFix = valueType != null ? "<" + valueType.toString() + ">()" : "()";
         return "new " + SUPPORTED_COLLECTION_INFO.get(outerClassType) + postFix;
@@ -126,32 +167,28 @@ public final class KnownTypeAdapterUtils {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
         DeclaredType declaredType = typeMirror instanceof DeclaredType ? (DeclaredType) typeMirror : null;
         TypeMirror keyType = declaredType != null && declaredType.getTypeArguments() != null &&
-                             declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
+                declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
                 .get(0) : null;
         TypeMirror paramType = declaredType != null && declaredType.getTypeArguments() != null &&
-                               declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
+                declaredType.getTypeArguments().size() == 2 ? declaredType.getTypeArguments()
                 .get(1) : null;
         String postFix = keyType != null && paramType != null ?
                 "<" + keyType.toString() + ", " + paramType.toString() + ">()" : "()";
 
-        if (outerClassType.equals(Map.class.getName())) {
-            return "new com.vimeo.stag.KnownTypeAdapters.MapInstantiator" + postFix;
-        } else if (outerClassType.equals(HashMap.class.getName())) {
-            return "new com.vimeo.stag.KnownTypeAdapters.HashMapInstantiator" + postFix;
-        } else if (outerClassType.equals(LinkedHashMap.class.getName())) {
-            return "new com.vimeo.stag.KnownTypeAdapters.LinkedHashMapInstantiator" + postFix;
-        } else if (outerClassType.equals(ConcurrentHashMap.class.getName())) {
-            return "new com.vimeo.stag.KnownTypeAdapters.ConcurrentHashMapInstantiator" + postFix;
+        String instantiator = SUPPORTED_MAP_INFO.get(outerClassType);
+
+        if (instantiator != null) {
+            return "new " + instantiator + postFix;
         } else {
             String params = keyType != null && paramType != null ?
                     "<" + keyType.toString() + ", " + paramType.toString() + ">" : "";
-            return "new com.google.gson.internal.ObjectConstructor<" + outerClassType + params + ">() " +
-                   "{ " +
-                   "\n@Override " +
-                   "\npublic " + outerClassType + params + " construct() {" +
-                   "\n\treturn new " + outerClassType + params + "();" +
-                   "\n}" +
-                   "}";
+            return "new " + sanitizeClassName(com.google.gson.internal.ObjectConstructor.class) + "<" + outerClassType + params + ">() " +
+                    "{ " +
+                    "\n@Override " +
+                    "\npublic " + outerClassType + params + " construct() {" +
+                    "\n\treturn new " + outerClassType + params + "();" +
+                    "\n}" +
+                    "}";
         }
     }
 
@@ -165,8 +202,8 @@ public final class KnownTypeAdapterUtils {
     public static String getNativeArrayInstantiator(@NotNull TypeMirror typeMirror) {
         String outerClassType = TypeUtils.getOuterClassType(typeMirror);
         return "new com.vimeo.stag.KnownTypeAdapters.PrimitiveArrayConstructor<" + outerClassType +
-               ">(){ @Override public " + outerClassType + "[] construct(int size){ return new " +
-               outerClassType + "[size]; } }";
+                ">(){ @Override public " + outerClassType + "[] construct(int size){ return new " +
+                outerClassType + "[size]; } }";
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
+import static com.vimeo.stag.processor.utils.TypeUtils.className;
+
 /**
  * This maintains a list of type vs the known type adapters.
  */
@@ -98,11 +100,6 @@ public final class KnownTypeAdapterUtils {
         SUPPORTED_MAP_INSTANTIATORS.put(HashMap.class.getName(), className(KnownTypeAdapters.HashMapInstantiator.class));
         SUPPORTED_MAP_INSTANTIATORS.put(LinkedHashMap.class.getName(), className(KnownTypeAdapters.LinkedHashMapInstantiator.class));
         SUPPORTED_MAP_INSTANTIATORS.put(ConcurrentHashMap.class.getName(), className(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
-    }
-
-    @NotNull
-    private static String className(@NotNull Class clazz) {
-        return clazz.getName().replace('$', '.');
     }
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -81,27 +81,27 @@ public final class KnownTypeAdapterUtils {
         KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_PRIMITIVE_TYPE_ADAPTER));
         KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_NULL_TYPE_ADAPTER));
 
-        SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), sanitizeClassName(KnownTypeAdapters.ArrayListInstantiator.class));
-        SUPPORTED_COLLECTION_INFO.put(List.class.getName(), sanitizeClassName(KnownTypeAdapters.ListInstantiator.class));
-        SUPPORTED_COLLECTION_INFO.put(Collection.class.getName(), sanitizeClassName(KnownTypeAdapters.CollectionInstantiator.class));
+        SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), className(KnownTypeAdapters.ArrayListInstantiator.class));
+        SUPPORTED_COLLECTION_INFO.put(List.class.getName(), className(KnownTypeAdapters.ListInstantiator.class));
+        SUPPORTED_COLLECTION_INFO.put(Collection.class.getName(), className(KnownTypeAdapters.CollectionInstantiator.class));
 
-        SUPPORTED_MAP_INFO.put(Map.class.getName(), sanitizeClassName(KnownTypeAdapters.MapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(HashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.HashMapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(LinkedHashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.LinkedHashMapInstantiator.class));
-        SUPPORTED_MAP_INFO.put(ConcurrentHashMap.class.getName(), sanitizeClassName(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(Map.class.getName(), className(KnownTypeAdapters.MapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(HashMap.class.getName(), className(KnownTypeAdapters.HashMapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(LinkedHashMap.class.getName(), className(KnownTypeAdapters.LinkedHashMapInstantiator.class));
+        SUPPORTED_MAP_INFO.put(ConcurrentHashMap.class.getName(), className(KnownTypeAdapters.ConcurrentHashMapInstantiator.class));
 
-        SUPPORTED_PRIMITIVE_ARRAY.put(int[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveIntegerArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(long[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveLongArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(double[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveDoubleArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(short[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveShortArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(char[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveCharArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(float[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveFloatArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(boolean[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveBooleanArrayAdapter.class));
-        SUPPORTED_PRIMITIVE_ARRAY.put(byte[].class.getSimpleName(), sanitizeClassName(KnownTypeAdapters.PrimitiveByteArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(int[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveIntegerArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(long[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveLongArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(double[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveDoubleArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(short[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveShortArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(char[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveCharArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(float[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveFloatArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(boolean[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveBooleanArrayAdapter.class));
+        SUPPORTED_PRIMITIVE_ARRAY.put(byte[].class.getSimpleName(), className(KnownTypeAdapters.PrimitiveByteArrayAdapter.class));
     }
 
     @NotNull
-    private static String sanitizeClassName(@NotNull Class clazz) {
+    private static String className(@NotNull Class clazz) {
         return clazz.getName().replace('$', '.');
     }
 
@@ -182,13 +182,13 @@ public final class KnownTypeAdapterUtils {
         } else {
             String params = keyType != null && paramType != null ?
                     "<" + keyType.toString() + ", " + paramType.toString() + ">" : "";
-            return "new " + sanitizeClassName(com.google.gson.internal.ObjectConstructor.class) + "<" + outerClassType + params + ">() " +
-                    "{ " +
-                    "\n@Override " +
-                    "\npublic " + outerClassType + params + " construct() {" +
-                    "\n\treturn new " + outerClassType + params + "();" +
-                    "\n}" +
-                    "}";
+            return "new " + className(com.google.gson.internal.ObjectConstructor.class) + "<" + outerClassType + params + ">() " +
+                   "{ " +
+                   "\n@Override " +
+                   "\npublic " + outerClassType + params + " construct() {" +
+                   "\n\treturn new " + outerClassType + params + "();" +
+                   "\n}" +
+                   "}";
         }
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterUtils.java
@@ -75,11 +75,11 @@ public final class KnownTypeAdapterUtils {
         KNOWN_TYPE_ADAPTERS.put(AtomicIntegerArray.class.getName(), typeAdapters(TypeAdapters.ATOMIC_INTEGER_ARRAY));
         KNOWN_TYPE_ADAPTERS.put(Currency.class.getName(), typeAdapters(TypeAdapters.CURRENCY));
         KNOWN_TYPE_ADAPTERS.put(Calendar.class.getName(), typeAdapters(TypeAdapters.CALENDAR));
-        KNOWN_TYPE_ADAPTERS.put(JsonElement.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ELEMENT_TYPE_ADAPTER));
-        KNOWN_TYPE_ADAPTERS.put(JsonObject.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_OBJECT_TYPE_ADAPTER));
-        KNOWN_TYPE_ADAPTERS.put(JsonArray.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ARRAY_TYPE_ADAPTER));
-        KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_PRIMITIVE_TYPE_ADAPTER));
-        KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_NULL_TYPE_ADAPTER));
+        KNOWN_TYPE_ADAPTERS.put(JsonElement.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ELEMENT));
+        KNOWN_TYPE_ADAPTERS.put(JsonObject.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_OBJECT));
+        KNOWN_TYPE_ADAPTERS.put(JsonArray.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_ARRAY));
+        KNOWN_TYPE_ADAPTERS.put(JsonPrimitive.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_PRIMITIVE));
+        KNOWN_TYPE_ADAPTERS.put(JsonNull.class.getName(), knownTypeAdapters(KnownTypeAdapters.JSON_NULL));
 
         SUPPORTED_COLLECTION_INFO.put(ArrayList.class.getName(), className(KnownTypeAdapters.ArrayListInstantiator.class));
         SUPPORTED_COLLECTION_INFO.put(List.class.getName(), className(KnownTypeAdapters.ListInstantiator.class));

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -23,10 +23,6 @@
  */
 package com.vimeo.stag.processor.utils;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -65,6 +61,21 @@ public final class TypeUtils {
     public static Types getUtils() {
         Preconditions.checkNotNull(sTypeUtils);
         return sTypeUtils;
+    }
+
+    /**
+     * Creates the full class name including package
+     * name for the given class. Anonymous classes
+     * and classes with the '$' character in their names
+     * are not supported.
+     *
+     * @param clazz the class to get the name of.
+     * @return the class's name, without any dollar
+     * signs for inner classes and with periods instead.
+     */
+    @NotNull
+    public static String className(@NotNull Class clazz) {
+        return clazz.getName().replace('$', '.');
     }
 
     /**
@@ -340,7 +351,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), declaredType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Parameterized Type - " + member.getValue().toString() +
-                            " resolved to - " + declaredType.toString());
+                                      " resolved to - " + declaredType.toString());
                 } else {
 
                     int index = inheritedTypes.indexOf(member.getKey().asType());
@@ -348,7 +359,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), concreteType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Type - " + member.getValue().toString() +
-                            " resolved to - " + concreteType.toString());
+                                      " resolved to - " + concreteType.toString());
                 }
             }
         }
@@ -404,9 +415,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedPrimitive(@NotNull String type) {
         return type.equals(long.class.getName()) || type.equals(double.class.getName()) ||
-                type.equals(boolean.class.getName()) || type.equals(float.class.getName()) ||
-                type.equals(int.class.getName()) || type.equals(char.class.getName()) ||
-                type.equals(short.class.getName()) || type.equals(byte.class.getName());
+               type.equals(boolean.class.getName()) || type.equals(float.class.getName()) ||
+               type.equals(int.class.getName()) || type.equals(char.class.getName()) ||
+               type.equals(short.class.getName()) || type.equals(byte.class.getName());
     }
 
     /**
@@ -441,8 +452,8 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(ArrayList.class.getName()) ||
-                outerClassType.equals(List.class.getName()) ||
-                outerClassType.equals(Collection.class.getName());
+               outerClassType.equals(List.class.getName()) ||
+               outerClassType.equals(Collection.class.getName());
     }
 
     /**
@@ -471,11 +482,11 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(Map.class.getName()) ||
-                outerClassType.equals(HashMap.class.getName()) ||
-                outerClassType.equals(ConcurrentHashMap.class.getName()) ||
-                outerClassType.equals("android.util.ArrayMap") ||
-                outerClassType.equals("android.support.v4.util.ArrayMap") ||
-                outerClassType.equals(LinkedHashMap.class.getName());
+               outerClassType.equals(HashMap.class.getName()) ||
+               outerClassType.equals(ConcurrentHashMap.class.getName()) ||
+               outerClassType.equals("android.util.ArrayMap") ||
+               outerClassType.equals("android.support.v4.util.ArrayMap") ||
+               outerClassType.equals(LinkedHashMap.class.getName());
     }
 
     /**
@@ -486,9 +497,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedNative(@NotNull String type) {
         return isSupportedPrimitive(type) || type.equals(String.class.getName()) ||
-                type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
-                type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
-                type.equals(Float.class.getName()) || type.equals(Number.class.getName());
+               type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
+               type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
+               type.equals(Float.class.getName()) || type.equals(Number.class.getName());
     }
 
     /**

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -63,7 +63,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * is used to read and write the values, and the ObjectConstructor tells the type of List to be instantiated. This will also support the scenario
  * where we have a nested list. In that case the valueTypeAdapter will be again a {@link ListTypeAdapter} with its value TypeAdapter
  */
-@SuppressWarnings({"unused", "WeakerAccess"})
+@SuppressWarnings({"WeakerAccess"})
 public final class KnownTypeAdapters {
 
     private KnownTypeAdapters() {
@@ -855,7 +855,7 @@ public final class KnownTypeAdapters {
                 public JsonPrimitive read(JsonReader in) throws IOException {
                     JsonElement jsonElement = JSON_ELEMENT_TYPE_ADAPTER.read(in);
                     return jsonElement != null &&
-                           jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
+                            jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
                 }
             }.nullSafe();
 

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -814,61 +814,61 @@ public final class KnownTypeAdapters {
         }
     }
 
-    public static final TypeAdapter<JsonElement> JSON_ELEMENT_TYPE_ADAPTER =
+    public static final TypeAdapter<JsonElement> JSON_ELEMENT =
             com.google.gson.internal.bind.TypeAdapters.JSON_ELEMENT.nullSafe();
 
-    public static final TypeAdapter<JsonObject> JSON_OBJECT_TYPE_ADAPTER = new TypeAdapter<JsonObject>() {
+    public static final TypeAdapter<JsonObject> JSON_OBJECT = new TypeAdapter<JsonObject>() {
         @Override
         public void write(JsonWriter out, JsonObject value) throws IOException {
-            JSON_ELEMENT_TYPE_ADAPTER.write(out, value);
+            JSON_ELEMENT.write(out, value);
         }
 
         @Override
         public JsonObject read(JsonReader in) throws IOException {
-            JsonElement jsonElement = JSON_ELEMENT_TYPE_ADAPTER.read(in);
+            JsonElement jsonElement = JSON_ELEMENT.read(in);
             return jsonElement != null && jsonElement.isJsonObject() ? jsonElement.getAsJsonObject() : null;
         }
     }.nullSafe();
 
-    public static final TypeAdapter<JsonArray> JSON_ARRAY_TYPE_ADAPTER = new TypeAdapter<JsonArray>() {
+    public static final TypeAdapter<JsonArray> JSON_ARRAY = new TypeAdapter<JsonArray>() {
         @Override
         public void write(JsonWriter out, JsonArray value) throws IOException {
-            JSON_ELEMENT_TYPE_ADAPTER.write(out, value);
+            JSON_ELEMENT.write(out, value);
         }
 
         @Override
         public JsonArray read(JsonReader in) throws IOException {
-            JsonElement jsonElement = JSON_ELEMENT_TYPE_ADAPTER.read(in);
+            JsonElement jsonElement = JSON_ELEMENT.read(in);
             return jsonElement != null && jsonElement.isJsonArray() ? jsonElement.getAsJsonArray() : null;
         }
     }.nullSafe();
 
-    public static final TypeAdapter<JsonPrimitive> JSON_PRIMITIVE_TYPE_ADAPTER =
+    public static final TypeAdapter<JsonPrimitive> JSON_PRIMITIVE =
             new TypeAdapter<JsonPrimitive>() {
 
                 @Override
                 public void write(JsonWriter out, JsonPrimitive value) throws IOException {
-                    JSON_ELEMENT_TYPE_ADAPTER.write(out, value);
+                    JSON_ELEMENT.write(out, value);
                 }
 
                 @Override
                 public JsonPrimitive read(JsonReader in) throws IOException {
-                    JsonElement jsonElement = JSON_ELEMENT_TYPE_ADAPTER.read(in);
+                    JsonElement jsonElement = JSON_ELEMENT.read(in);
                     return jsonElement != null &&
                             jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
                 }
             }.nullSafe();
 
-    public static final TypeAdapter<JsonNull> JSON_NULL_TYPE_ADAPTER = new TypeAdapter<JsonNull>() {
+    public static final TypeAdapter<JsonNull> JSON_NULL = new TypeAdapter<JsonNull>() {
 
         @Override
         public void write(JsonWriter out, JsonNull value) throws IOException {
-            JSON_ELEMENT_TYPE_ADAPTER.write(out, value);
+            JSON_ELEMENT.write(out, value);
         }
 
         @Override
         public JsonNull read(JsonReader in) throws IOException {
-            JsonElement jsonElement = JSON_ELEMENT_TYPE_ADAPTER.read(in);
+            JsonElement jsonElement = JSON_ELEMENT.read(in);
             return jsonElement != null && jsonElement.isJsonNull() ? jsonElement.getAsJsonNull() : null;
         }
     }.nullSafe();

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -63,7 +63,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * is used to read and write the values, and the ObjectConstructor tells the type of List to be instantiated. This will also support the scenario
  * where we have a nested list. In that case the valueTypeAdapter will be again a {@link ListTypeAdapter} with its value TypeAdapter
  */
-@SuppressWarnings({"WeakerAccess"})
 public final class KnownTypeAdapters {
 
     private KnownTypeAdapters() {
@@ -207,8 +206,8 @@ public final class KnownTypeAdapters {
         final TypeAdapter<T> mValueTypeAdapter;
         final PrimitiveArrayConstructor<T> mObjectCreator;
 
-        public ArrayTypeAdapter(TypeAdapter<T> valueTypeAdapter,
-                                PrimitiveArrayConstructor<T> instanceCreator) {
+        public ArrayTypeAdapter(@NotNull TypeAdapter<T> valueTypeAdapter,
+                                @NotNull PrimitiveArrayConstructor<T> instanceCreator) {
             this.mValueTypeAdapter = valueTypeAdapter;
             this.mObjectCreator = instanceCreator;
         }
@@ -595,7 +594,8 @@ public final class KnownTypeAdapters {
         private final TypeAdapter<V> valueTypeAdapter;
         private final ObjectConstructor<T> objectConstructor;
 
-        public ListTypeAdapter(TypeAdapter<V> valueTypeAdapter, ObjectConstructor<T> objectConstructor) {
+        public ListTypeAdapter(@NotNull TypeAdapter<V> valueTypeAdapter,
+                               @NotNull ObjectConstructor<T> objectConstructor) {
             this.valueTypeAdapter = valueTypeAdapter;
             this.objectConstructor = objectConstructor;
         }
@@ -643,8 +643,9 @@ public final class KnownTypeAdapters {
         private final TypeAdapter<V> valueTypeAdapter;
         private final TypeAdapter<K> keyTypeAdapter;
 
-        public MapTypeAdapter(TypeAdapter<K> keyTypeAdapter, TypeAdapter<V> valueTypeAdapter,
-                              ObjectConstructor<T> objectConstructor) {
+        public MapTypeAdapter(@NotNull TypeAdapter<K> keyTypeAdapter,
+                              @NotNull TypeAdapter<V> valueTypeAdapter,
+                              @NotNull ObjectConstructor<T> objectConstructor) {
             this.keyTypeAdapter = keyTypeAdapter;
             this.valueTypeAdapter = valueTypeAdapter;
             this.objectConstructor = objectConstructor;
@@ -726,7 +727,8 @@ public final class KnownTypeAdapters {
             return map;
         }
 
-        private static String keyToString(JsonElement keyElement) {
+        @NotNull
+        private static String keyToString(@NotNull JsonElement keyElement) {
             if (keyElement.isJsonPrimitive()) {
                 JsonPrimitive primitive = keyElement.getAsJsonPrimitive();
                 if (primitive.isNumber()) {
@@ -753,7 +755,7 @@ public final class KnownTypeAdapters {
 
         private final Gson gson;
 
-        public ObjectTypeAdapter(Gson gson) {
+        public ObjectTypeAdapter(@NotNull Gson gson) {
             this.gson = gson;
         }
 
@@ -843,21 +845,20 @@ public final class KnownTypeAdapters {
         }
     }.nullSafe();
 
-    public static final TypeAdapter<JsonPrimitive> JSON_PRIMITIVE =
-            new TypeAdapter<JsonPrimitive>() {
+    public static final TypeAdapter<JsonPrimitive> JSON_PRIMITIVE = new TypeAdapter<JsonPrimitive>() {
 
-                @Override
-                public void write(JsonWriter out, JsonPrimitive value) throws IOException {
-                    JSON_ELEMENT.write(out, value);
-                }
+        @Override
+        public void write(JsonWriter out, JsonPrimitive value) throws IOException {
+            JSON_ELEMENT.write(out, value);
+        }
 
-                @Override
-                public JsonPrimitive read(JsonReader in) throws IOException {
-                    JsonElement jsonElement = JSON_ELEMENT.read(in);
-                    return jsonElement != null &&
-                            jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
-                }
-            }.nullSafe();
+        @Override
+        public JsonPrimitive read(JsonReader in) throws IOException {
+            JsonElement jsonElement = JSON_ELEMENT.read(in);
+            return jsonElement != null &&
+                   jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
+        }
+    }.nullSafe();
 
     public static final TypeAdapter<JsonNull> JSON_NULL = new TypeAdapter<JsonNull>() {
 

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -165,7 +165,7 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
-     * Test for {@link KnownTypeAdapters#JSON_OBJECT_TYPE_ADAPTER}
+     * Test for {@link KnownTypeAdapters#JSON_OBJECT}
      *
      * @throws Exception
      */
@@ -173,7 +173,7 @@ public class KnownTypeAdaptersTest {
     public void testForJsonObjectTypeAdapter() throws Exception {
         JsonObject jsonObject = Utils.createDummyJsonObject();
 
-        TypeAdapter<JsonObject> jsonObjectTypeAdapter = KnownTypeAdapters.JSON_OBJECT_TYPE_ADAPTER;
+        TypeAdapter<JsonObject> jsonObjectTypeAdapter = KnownTypeAdapters.JSON_OBJECT;
         StringWriter stringWriter = new StringWriter();
         jsonObjectTypeAdapter.write(new JsonWriter(stringWriter), jsonObject);
         String jsonString = stringWriter.toString();
@@ -184,7 +184,7 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
-     * Test for {@link KnownTypeAdapters#JSON_ARRAY_TYPE_ADAPTER}
+     * Test for {@link KnownTypeAdapters#JSON_ARRAY}
      *
      * @throws Exception
      */
@@ -192,7 +192,7 @@ public class KnownTypeAdaptersTest {
     public void testForJsonArrayTypeAdapter() throws Exception {
         JsonArray jsonArray = Utils.createDummyJsonArray();
 
-        TypeAdapter<JsonArray> jsonObjectTypeAdapter = KnownTypeAdapters.JSON_ARRAY_TYPE_ADAPTER;
+        TypeAdapter<JsonArray> jsonObjectTypeAdapter = KnownTypeAdapters.JSON_ARRAY;
         StringWriter stringWriter = new StringWriter();
         jsonObjectTypeAdapter.write(new JsonWriter(stringWriter), jsonArray);
         String jsonString = stringWriter.toString();


### PR DESCRIPTION
#### Summary
We were using hardcoded strings for all the adapter fields in the `KnownTypeAdaptersUtils` class. This had a couple of effects:
- It made it look like most of the classes and fields in `KnownTypeAdapters` were unused to the compiler. This meant we had to suppress helpful lint warnings in that class.
- It made any refactoring more difficult.
- It made the code susceptible to any other changes, such as changes to Gson. With this change it is much more clear if there is a problem with the class referenced by Gson.

I also did some general refactoring around this code to make it more clear.