### PR TITLE
Self-referential generic type adapters causing stack overflows

### DIFF
--- a/sample/src/test/java/com/vimeo/sample/model/ExternalModelExample2Test.java
+++ b/sample/src/test/java/com/vimeo/sample/model/ExternalModelExample2Test.java
@@ -1,5 +1,7 @@
 package com.vimeo.sample.model;
 
+import com.vimeo.sample.Utils;
+
 import org.junit.Test;
 
 /**
@@ -9,8 +11,7 @@ public class ExternalModelExample2Test {
 
     @Test
     public void typeAdapterWasGenerated() throws Exception {
-        // TODO: This use case is currently broken 2/2/17 [AR]
-//        Utils.verifyTypeAdapterGeneration(ExternalModelExample2.class);
+        Utils.verifyTypeAdapterGeneration(ExternalModelExample2.class);
     }
 
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -119,13 +119,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
      * This is used to generate the type token code for the types that are known.
      */
     @Nullable
-    private static String getTypeAdapterCode(@NotNull TypeMirror fieldType,
-                                             @NotNull TypeSpec.Builder adapterBuilder,
-                                             @NotNull MethodSpec.Builder constructorBuilder,
-                                             @NotNull TypeTokenConstantsGenerator typeTokenConstantsGenerator,
-                                             @NotNull Map<TypeVariable, String> typeVarsMap,
-                                             @NotNull StagGenerator stagGenerator,
-                                             @NotNull AdapterFieldInfo adapterFieldInfo) {
+    private String getTypeAdapterCode(@NotNull TypeMirror fieldType, @NotNull TypeSpec.Builder adapterBuilder,
+                                      @NotNull MethodSpec.Builder constructorBuilder,
+                                      @NotNull TypeTokenConstantsGenerator typeTokenConstantsGenerator,
+                                      @NotNull Map<TypeVariable, String> typeVarsMap,
+                                      @NotNull StagGenerator stagGenerator,
+                                      @NotNull AdapterFieldInfo adapterFieldInfo) {
         String result = null;
         if (!TypeUtils.isConcreteType(fieldType)) {
             if (fieldType.getKind() == TypeKind.TYPEVAR) {
@@ -187,14 +186,19 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
                     String adapterCode;
                     if (null != externalAdapterInfo) {
-                        //if the field type is an external model
+                        // If the field type is an external model
                         adapterCode = externalAdapterInfo.getInitializer("gson", typeAdapterCode);
                     } else {
                         ClassInfo classInfo = new ClassInfo(outerClass);
-                        int idx1 = fieldType.toString().indexOf("<");
-                        String argument = idx1 > 0 ? fieldType.toString().substring(idx1) : "";
-                        adapterCode = "new " + classInfo.getTypeAdapterQualifiedClassName() + argument +
-                                      "(gson, stagFactory" + typeAdapterCode + ")";
+                        if (classInfo.equals(mInfo)) {
+                            // In this case the adapter will be the same as the one we are generating
+                            adapterCode = "this";
+                        } else {
+                            int idx1 = fieldType.toString().indexOf("<");
+                            String argument = idx1 > 0 ? fieldType.toString().substring(idx1) : "";
+                            adapterCode = "new " + classInfo.getTypeAdapterQualifiedClassName() + argument +
+                                          "(gson, stagFactory" + typeAdapterCode + ")";
+                        }
                     }
                     return adapterCode;
                 }
@@ -313,13 +317,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
     /**
      * Returns the adapter code for the known types.
      */
-    private static String getAdapterAccessor(@NotNull TypeMirror fieldType,
-                                             @NotNull TypeSpec.Builder adapterBuilder,
-                                             @NotNull MethodSpec.Builder constructorBuilder,
-                                             @NotNull TypeTokenConstantsGenerator typeTokenConstantsGenerator,
-                                             @NotNull Map<TypeVariable, String> typeVarsMap,
-                                             @NotNull StagGenerator stagGenerator,
-                                             @NotNull AdapterFieldInfo adapterFieldInfo) {
+    private String getAdapterAccessor(@NotNull TypeMirror fieldType, @NotNull TypeSpec.Builder adapterBuilder,
+                                      @NotNull MethodSpec.Builder constructorBuilder,
+                                      @NotNull TypeTokenConstantsGenerator typeTokenConstantsGenerator,
+                                      @NotNull Map<TypeVariable, String> typeVarsMap,
+                                      @NotNull StagGenerator stagGenerator,
+                                      @NotNull AdapterFieldInfo adapterFieldInfo) {
 
         String knownTypeAdapter = KnownTypeAdapterUtils.getKnownTypeAdapterForType(fieldType);
 
@@ -582,12 +585,13 @@ public class TypeAdapterGenerator extends AdapterGenerator {
     }
 
     @NotNull
-    private static AdapterFieldInfo addAdapterFields(
-            @Nullable StagGenerator.GenericClassInfo genericClassInfo,
-            @NotNull TypeSpec.Builder adapterBuilder, @NotNull MethodSpec.Builder constructorBuilder,
-            @NotNull Map<Element, TypeMirror> memberVariables,
-            @NotNull TypeTokenConstantsGenerator typeTokenConstantsGenerator,
-            @NotNull Map<TypeVariable, String> typeVarsMap, @NotNull StagGenerator stagGenerator) {
+    private AdapterFieldInfo addAdapterFields(@Nullable StagGenerator.GenericClassInfo genericClassInfo,
+                                              @NotNull TypeSpec.Builder adapterBuilder,
+                                              @NotNull MethodSpec.Builder constructorBuilder,
+                                              @NotNull Map<Element, TypeMirror> memberVariables, @NotNull
+                                                      TypeTokenConstantsGenerator typeTokenConstantsGenerator,
+                                              @NotNull Map<TypeVariable, String> typeVarsMap,
+                                              @NotNull StagGenerator stagGenerator) {
 
         HashSet<TypeMirror> typeSet = new HashSet<>(memberVariables.values());
         AdapterFieldInfo result = new AdapterFieldInfo(typeSet.size());

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import javax.lang.model.type.TypeMirror;
 
-public class ClassInfo {
+public final class ClassInfo {
 
     @NotNull
     private final String mClassName;
@@ -125,5 +125,30 @@ public class ClassInfo {
     @Nullable
     public List<? extends TypeMirror> getTypeArguments() {
         return TypeUtils.getTypeArguments(mType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClassInfo classInfo = (ClassInfo) o;
+
+        return mClassName.equals(classInfo.mClassName) && mPackageName.equals(classInfo.mPackageName) &&
+               mTypeName.equals(classInfo.mTypeName) && mType.equals(classInfo.mType);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mClassName.hashCode();
+        result = 31 * result + mPackageName.hashCode();
+        result = 31 * result + mTypeName.hashCode();
+        result = 31 * result + mType.hashCode();
+        return result;
     }
 }


### PR DESCRIPTION
#### Ticket
https://github.com/vimeo/stag-java/issues/51 - TypeAdapters of generic classes referencing themselves caused stack overflows

#### Ticket Summary
If a generic class referenced itself (see `sample/ExternalModelExample2`), the type adapter would try to create an instance of itself in the constructor, resulting in a stack overflow.

#### Implementation Summary
The solution was to recognize that the adapter being instantiated was of the same type with the same arguments as the current class, and to instead point at `this`. This fixed the bug. I also uncommented the test case that checks this scenario.

#### How to Test
Create a generic model that references itself. Instantiate the TypeAdapter created. Observe that it does not cause a stack overflow.
