### PR TITLE
Fixing issue #54 : Duplicate TypeAdapters being generated

### DIFF
--- a/sample-model/src/main/java/com/vimeo/sample_model/BaseExternalModel.java
+++ b/sample-model/src/main/java/com/vimeo/sample_model/BaseExternalModel.java
@@ -1,0 +1,11 @@
+package com.vimeo.sample_model;
+
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class BaseExternalModel {
+    public String type;
+
+    public int baseValue;
+
+}

--- a/sample/src/main/java/com/vimeo/sample/model/ExternalModelDerivedExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/ExternalModelDerivedExample.java
@@ -1,0 +1,10 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.sample_model.BaseExternalModel;
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class ExternalModelDerivedExample extends BaseExternalModel {
+
+    public Boolean derivedBoolean;
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -140,7 +140,7 @@ public final class StagProcessor extends AbstractProcessor {
             Element enclosingClassElement = variableElement.getEnclosingElement();
             TypeMirror enclosingClass = enclosingClassElement.asType();
             DebugLog.log("Annotated type: " + enclosingClass + "\n");
-            SupportedTypesModel.getInstance().getSupportedType(enclosingClass);
+            SupportedTypesModel.getInstance().addSupportedType(enclosingClass);
         }
 
         Filer filer = processingEnv.getFiler();
@@ -202,7 +202,7 @@ public final class StagProcessor extends AbstractProcessor {
         if (ElementUtils.isSupportedElementKind(useStagElement)) {
             TypeMirror rootType = useStagElement.asType();
             DebugLog.log("Annotated type: " + rootType + "\n");
-            SupportedTypesModel.getInstance().getSupportedType(rootType);
+            SupportedTypesModel.getInstance().addSupportedType(rootType);
         }
 
         List<? extends Element> enclosedElements = useStagElement.getEnclosedElements();

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -759,6 +759,9 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         }
 
         AnnotatedClass annotatedClass = SupportedTypesModel.getInstance().getSupportedType(typeMirror);
+        if(null == annotatedClass) {
+            throw new IllegalStateException("The AnnotatedClass class can't be null in TypeAdapterGenerator : " + typeMirror.toString());
+        }
         Map<Element, TypeMirror> memberVariables = annotatedClass.getMemberVariables();
 
         AdapterFieldInfo adapterFieldInfo =

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -77,7 +77,7 @@ public class AnnotatedClass {
             DebugLog.log(TAG, "\t\tInherited Type - " + inheritedType.toString());
 
             AnnotatedClass genericInheritedType =
-                    SupportedTypesModel.getInstance().getSupportedType(inheritedType);
+                    SupportedTypesModel.getInstance().addToKnownInheritedType(inheritedType);
 
             LinkedHashMap<Element, TypeMirror> inheritedMemberVariables =
                     TypeUtils.getConcreteMembers(inheritedType, genericInheritedType.getElement(),

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -117,8 +117,6 @@ public final class SupportedTypesModel {
      */
     @NotNull
     public AnnotatedClass addToKnownInheritedType(TypeMirror type) {
-        return addSupportedType(type);
-        /*
         String outerClassType = TypeUtils.getOuterClassType(type);
         AnnotatedClass model = getSupportedType(outerClassType);
         if(null == model) {
@@ -128,7 +126,7 @@ public final class SupportedTypesModel {
                 mKnownInheritedTypesMap.put(outerClassType, model);
             }
         }
-        return model;*/
+        return model;
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -43,6 +43,7 @@ public final class SupportedTypesModel {
     @Nullable
     private static SupportedTypesModel sInstance;
     private final Map<String, AnnotatedClass> mSupportedTypesMap = new HashMap<>();
+    private final Map<String, AnnotatedClass> mKnownInheritedTypesMap = new HashMap<>();
     private final Set<Element> mSupportedTypes = new HashSet<>();
     private final Set<TypeMirror> mSupportedTypesMirror = new HashSet<>();
     private final Set<ExternalAdapterInfo> mExternalSupportedAdapters = new HashSet<>();
@@ -85,13 +86,70 @@ public final class SupportedTypesModel {
      * @return the AnnotatedClass object associated
      * with the class type.
      */
-    @NotNull
+    @Nullable
     public AnnotatedClass getSupportedType(@NotNull TypeMirror type) {
-        AnnotatedClass model = mSupportedTypesMap.get(TypeUtils.getOuterClassType(type));
+        return getSupportedType(TypeUtils.getOuterClassType(type));
+    }
+
+    /**
+     * Retrieves the AnnotatedClass object for the
+     * specific TypeMirror.
+     *
+     * @param type the type that maps to a specific
+     *             AnnotatedClass.
+     * @return the AnnotatedClass object associated
+     * with the class type.
+     */
+    @Nullable
+    private AnnotatedClass getSupportedType(@NotNull String type) {
+        return mSupportedTypesMap.get(type);
+    }
+
+    /**
+     * Adds an AnnotatedClass object for the
+     * specific TypeMirror if it does not exist in the list of
+     * known inherited types
+     *
+     * @param type the type that maps to a specific
+     *             AnnotatedClass.
+     * @return the AnnotatedClass object associated
+     * with the class type.
+     */
+    @NotNull
+    public AnnotatedClass addToKnownInheritedType(TypeMirror type) {
+        return addSupportedType(type);
+        /*
+        String outerClassType = TypeUtils.getOuterClassType(type);
+        AnnotatedClass model = getSupportedType(outerClassType);
+        if(null == model) {
+            model = mKnownInheritedTypesMap.get(outerClassType);
+            if(null == model) {
+                model = new AnnotatedClass(TypeUtils.getUtils().asElement(type));
+                mKnownInheritedTypesMap.put(outerClassType, model);
+            }
+        }
+        return model;*/
+    }
+
+    /**
+     * Adds an AnnotatedClass object for the
+     * specific TypeMirror if it does not exist.
+     *
+     * @param type the type that maps to a specific
+     *             AnnotatedClass.
+     * @return the AnnotatedClass object associated
+     * with the class type.
+     */
+    @NotNull
+    public AnnotatedClass addSupportedType(@NotNull TypeMirror type) {
+        String outerClassType = TypeUtils.getOuterClassType(type);
+        AnnotatedClass model = getSupportedType(outerClassType);
 
         if (model == null) {
-            // TODO: Refactor so that getSupportedType doesn't modify internal state 2/3/17 [AR]
-            model = new AnnotatedClass(TypeUtils.getUtils().asElement(type));
+            model = mKnownInheritedTypesMap.get(outerClassType);
+            if(null == model) {
+                model = new AnnotatedClass(TypeUtils.getUtils().asElement(type));
+            }
             addSupportedType(model);
         }
         return model;
@@ -123,4 +181,6 @@ public final class SupportedTypesModel {
     public Set<ExternalAdapterInfo> getExternalSupportedAdapters() {
         return new HashSet<>(mExternalSupportedAdapters);
     }
+
+
 }


### PR DESCRIPTION
By default the base classes were being added to the list of classes for which we were generating the type adapters. With this change now the list of classes for which we generate the TypeAdapters are added only by the StagProcessor. The inherited classes are kept in a separate map to reuse the AnnotatedClass object.

#### Ticket
Issues #54 

#### Ticket Summary
Duplicate TypeAdapters were being generated when the base class existed in another module and the derived class in another one and both of them were using Stag for TypeAdapter generation.

#### Implementation Summary
For the inherited types changed the implementation to cache the AnnotatedClass in another map. If that class is found to be using Stag by the StagProcessor it will be reused as well.

#### How to Test
BaseExternalModel would be regenerated if we revert the changes 
