### PR TITLE
Cleaning up GenericClassInfo class and cleaning up utils classes

### DIFF
--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -115,9 +115,10 @@ public final class StagProcessor extends AbstractProcessor {
 
         String packageName = getOptionalPackageName(processingEnv);
 
-        String stagFactoryGeneratedName = StagGenerator.getGeneratedFactoryClassAndPackage(packageName);
         TypeUtils.initialize(processingEnv.getTypeUtils());
         ElementUtils.initialize(processingEnv.getElementUtils());
+
+        String stagFactoryGeneratedName = StagGenerator.getGeneratedFactoryClassAndPackage(packageName);
         SupportedTypesModel.getInstance().initialize(stagFactoryGeneratedName);
 
         DebugLog.log("\nBeginning @UseStag annotation processing\n");

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -535,7 +535,7 @@ public class StagGenerator {
 
         final boolean mHasUnknownVarTypeFields;
 
-        private GenericClassInfo(boolean hasUnknownVarTypeFields) {
+        GenericClassInfo(boolean hasUnknownVarTypeFields) {
             mHasUnknownVarTypeFields = hasUnknownVarTypeFields;
         }
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -52,16 +52,8 @@ public final class ClassInfo {
         mType = typeMirror;
         mPackageName = ElementUtils.getPackage(mType);
 
-        String classAndPackage = mType.toString();
+        String classAndPackage = TypeUtils.getClassNameFromTypeMirror(mType);
 
-        /**
-         * This is done to avoid the generic template from being included in the file name to be generated
-         * (since it will be an invalid file name)
-         */
-        int idx = classAndPackage.indexOf("<");
-        if (idx > 0) {
-            classAndPackage = classAndPackage.substring(0, idx);
-        }
         mTypeName = classAndPackage;
         mClassName = classAndPackage.substring(mPackageName.length() + 1, classAndPackage.length())
                 .replaceAll("\\.", "\\$");
@@ -139,7 +131,7 @@ public final class ClassInfo {
         ClassInfo classInfo = (ClassInfo) o;
 
         return mClassName.equals(classInfo.mClassName) && mPackageName.equals(classInfo.mPackageName) &&
-               mTypeName.equals(classInfo.mTypeName) && mType.equals(classInfo.mType);
+                mTypeName.equals(classInfo.mTypeName) && mType.equals(classInfo.mType);
 
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -122,7 +122,7 @@ public final class SupportedTypesModel {
         if (null == model) {
             model = mKnownInheritedTypesMap.get(outerClassType);
             if (null == model) {
-                model = new AnnotatedClass(TypeUtils.getUtils().asElement(type));
+                model = new AnnotatedClass(TypeUtils.getElementFromTypeMirror(type));
                 mKnownInheritedTypesMap.put(outerClassType, model);
             }
         }
@@ -146,7 +146,7 @@ public final class SupportedTypesModel {
         if (model == null) {
             model = mKnownInheritedTypesMap.get(outerClassType);
             if (null == model) {
-                model = new AnnotatedClass(TypeUtils.getUtils().asElement(type));
+                model = new AnnotatedClass(TypeUtils.getElementFromTypeMirror(type));
             }
             addSupportedType(model);
         }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -35,6 +35,7 @@ import javax.lang.model.util.Elements;
 
 public final class ElementUtils {
 
+    @Nullable
     private static Elements sElementUtils;
 
     private ElementUtils() {
@@ -57,7 +58,6 @@ public final class ElementUtils {
         return null != typeElement ? typeElement.asType() : null;
     }
 
-
     @Nullable
     public static TypeElement getTypeElementFromQualifiedName(@NotNull String qualifiedName) {
         Elements elements = ElementUtils.getUtils();
@@ -66,17 +66,9 @@ public final class ElementUtils {
 
     @NotNull
     public static String getPackage(@NotNull TypeMirror type) {
-        Element element = TypeUtils.getUtils().asElement(type);
-        PackageElement packageElement = sElementUtils.getPackageOf(element);
+        Element element = TypeUtils.getElementFromTypeMirror(type);
+        PackageElement packageElement = getUtils().getPackageOf(element);
         return packageElement.getQualifiedName().toString();
-    }
-
-    public static boolean isEnum(@Nullable Element element) {
-        return element != null && element.getKind() == ElementKind.ENUM;
-    }
-
-    public static boolean isClass(@Nullable Element element) {
-        return element != null && element.getKind() == ElementKind.CLASS;
     }
 
     /**
@@ -93,4 +85,5 @@ public final class ElementUtils {
         ElementKind elementKind = element.getKind();
         return elementKind == ElementKind.CLASS || elementKind == ElementKind.ENUM;
     }
+
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -47,6 +47,7 @@ import javax.lang.model.util.Types;
 public final class TypeUtils {
 
     private static final String TAG = TypeUtils.class.getSimpleName();
+    @Nullable
     private static Types sTypeUtils;
 
     private TypeUtils() {
@@ -58,7 +59,7 @@ public final class TypeUtils {
     }
 
     @NotNull
-    public static Types getUtils() {
+    private static Types getUtils() {
         Preconditions.checkNotNull(sTypeUtils);
         return sTypeUtils;
     }
@@ -204,7 +205,7 @@ public final class TypeUtils {
         if (typeMirror.getKind() == TypeKind.TYPEVAR) {
             return false;
         }
-        if (isPrimitive(typeMirror, sTypeUtils)) {
+        if (isPrimitive(typeMirror, getUtils())) {
             return true;
         }
         if (typeMirror instanceof DeclaredType) {
@@ -342,16 +343,16 @@ public final class TypeUtils {
                         }
                     }
 
-                    TypeElement typeElement = (TypeElement) sTypeUtils.asElement(member.getValue());
+                    TypeElement typeElement = (TypeElement) getUtils().asElement(member.getValue());
                     TypeMirror[] concreteTypeArray =
                             concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
 
-                    DeclaredType declaredType = sTypeUtils.getDeclaredType(typeElement, concreteTypeArray);
+                    DeclaredType declaredType = getUtils().getDeclaredType(typeElement, concreteTypeArray);
 
                     map.put(member.getKey(), declaredType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Parameterized Type - " + member.getValue().toString() +
-                                      " resolved to - " + declaredType.toString());
+                            " resolved to - " + declaredType.toString());
                 } else {
 
                     int index = inheritedTypes.indexOf(member.getKey().asType());
@@ -359,7 +360,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), concreteType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Type - " + member.getValue().toString() +
-                                      " resolved to - " + concreteType.toString());
+                            " resolved to - " + concreteType.toString());
                 }
             }
         }
@@ -415,9 +416,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedPrimitive(@NotNull String type) {
         return type.equals(long.class.getName()) || type.equals(double.class.getName()) ||
-               type.equals(boolean.class.getName()) || type.equals(float.class.getName()) ||
-               type.equals(int.class.getName()) || type.equals(char.class.getName()) ||
-               type.equals(short.class.getName()) || type.equals(byte.class.getName());
+                type.equals(boolean.class.getName()) || type.equals(float.class.getName()) ||
+                type.equals(int.class.getName()) || type.equals(char.class.getName()) ||
+                type.equals(short.class.getName()) || type.equals(byte.class.getName());
     }
 
     /**
@@ -452,8 +453,8 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(ArrayList.class.getName()) ||
-               outerClassType.equals(List.class.getName()) ||
-               outerClassType.equals(Collection.class.getName());
+                outerClassType.equals(List.class.getName()) ||
+                outerClassType.equals(Collection.class.getName());
     }
 
     /**
@@ -482,11 +483,11 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(Map.class.getName()) ||
-               outerClassType.equals(HashMap.class.getName()) ||
-               outerClassType.equals(ConcurrentHashMap.class.getName()) ||
-               outerClassType.equals("android.util.ArrayMap") ||
-               outerClassType.equals("android.support.v4.util.ArrayMap") ||
-               outerClassType.equals(LinkedHashMap.class.getName());
+                outerClassType.equals(HashMap.class.getName()) ||
+                outerClassType.equals(ConcurrentHashMap.class.getName()) ||
+                outerClassType.equals("android.util.ArrayMap") ||
+                outerClassType.equals("android.support.v4.util.ArrayMap") ||
+                outerClassType.equals(LinkedHashMap.class.getName());
     }
 
     /**
@@ -497,9 +498,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedNative(@NotNull String type) {
         return isSupportedPrimitive(type) || type.equals(String.class.getName()) ||
-               type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
-               type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
-               type.equals(Float.class.getName()) || type.equals(Number.class.getName());
+                type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
+                type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
+                type.equals(Float.class.getName()) || type.equals(Number.class.getName());
     }
 
     /**
@@ -510,4 +511,24 @@ public final class TypeUtils {
         return (type instanceof ArrayType) ? ((ArrayType) type).getComponentType() : ((DeclaredType) type).getTypeArguments()
                 .get(0);
     }
+
+    @NotNull
+    public static String getClassNameFromTypeMirror(@NotNull TypeMirror typeMirror) {
+        String classAndPackage = typeMirror.toString();
+
+        // This is done to avoid the generic template from being included in the file name
+        // to be generated (since it will be an invalid file name)
+        int idx = classAndPackage.indexOf("<");
+        if (idx > 0) {
+            classAndPackage = classAndPackage.substring(0, idx);
+        }
+
+        return classAndPackage;
+    }
+
+    @NotNull
+    public static Element getElementFromTypeMirror(@NotNull TypeMirror typeMirror) {
+        return getUtils().asElement(typeMirror);
+    }
+
 }

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.java
@@ -103,24 +103,4 @@ public class ElementUtilsUnitTest extends BaseUnitTest {
                 ElementUtils.getPackage(Utils.getTypeMirrorFromClass(Object.class)));
     }
 
-    @Test
-    public void testIsEnum() throws Exception {
-        Assert.assertFalse(ElementUtils.isEnum(null));
-
-        Element enumElement = Utils.getElementFromClass(DummyEnumClass.class);
-        Assert.assertTrue(ElementUtils.isEnum(enumElement));
-
-        Element concreteElement = Utils.getElementFromClass(DummyConcreteClass.class);
-        Assert.assertFalse(ElementUtils.isEnum(concreteElement));
-
-        Element genericElement = Utils.getElementFromClass(DummyGenericClass.class);
-        Assert.assertFalse(ElementUtils.isEnum(genericElement));
-
-        Element inheritedElement = Utils.getElementFromClass(DummyInheritedClass.class);
-        Assert.assertFalse(ElementUtils.isEnum(inheritedElement));
-
-        Element abstractElement = Utils.getElementFromClass(DummyAbstractClass.class);
-        Assert.assertFalse(ElementUtils.isEnum(abstractElement));
-    }
-
 }

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
@@ -75,26 +75,6 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testInitialize_works() throws Exception {
-        // Initialize it to null in order to test correctly
-        //noinspection ConstantConditions
-        TypeUtils.initialize(null);
-
-        boolean exceptionThrown = false;
-
-        try {
-            TypeUtils.getUtils();
-        } catch (NullPointerException e) {
-            exceptionThrown = true;
-        }
-
-        assertTrue(exceptionThrown);
-
-        TypeUtils.initialize(types);
-        assertNotNull(TypeUtils.getUtils());
-    }
-
-    @Test
     public void getInheritedType_isCorrect() throws Exception {
         TypeMirror concreteType =
                 TypeUtils.getInheritedType(Utils.getElementFromClass(DummyInheritedClass.class));


### PR DESCRIPTION
#### Summary
- Removed unnecessary field from GenericClassInfo.
- Fixed NPE lint warnings in TypeUtils and ElementUtils.
- Cleaned up TypeUtils and ElementUtils APIs.
- Deleted unnecessary unit tests.
