### PR TITLE
More KnownTypeAdapter tests

### DIFF
--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -77,7 +77,7 @@ public final class KnownTypeAdapters {
         public Byte read(JsonReader in) throws IOException {
             try {
                 int intValue = in.nextInt();
-                return Byte.valueOf((byte) intValue);
+                return (byte) intValue;
             } catch (NumberFormatException e) {
                 throw new JsonSyntaxException(e);
             }
@@ -92,7 +92,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link byte}.
      */
-    public static final class PrimitiveByteTypeAdapter{
+    public static final class PrimitiveByteTypeAdapter {
 
         public static byte read(JsonReader in, byte defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -100,7 +100,7 @@ public final class KnownTypeAdapters {
                 return defaultValue;
             }
             try {
-                return (byte)in.nextInt();
+                return (byte) in.nextInt();
             } catch (NumberFormatException e) {
                 throw new JsonSyntaxException(e);
             }
@@ -119,7 +119,7 @@ public final class KnownTypeAdapters {
         @Override
         public Short read(JsonReader in) throws IOException {
             try {
-                return Short.valueOf((short)in.nextInt());
+                return (short) in.nextInt();
             } catch (NumberFormatException e) {
                 throw new JsonSyntaxException(e);
             }
@@ -134,7 +134,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link short}.
      */
-    public static final class PrimitiveShortTypeAdapter{
+    public static final class PrimitiveShortTypeAdapter {
 
         public static short read(JsonReader in, short defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -175,7 +175,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link int}.
      */
-    public static final class PrimitiveIntTypeAdapter{
+    public static final class PrimitiveIntTypeAdapter {
 
         public static int read(JsonReader in, int defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -218,7 +218,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link long}.
      */
-    public static final class PrimitiveLongTypeAdapter{
+    public static final class PrimitiveLongTypeAdapter {
 
         public static long read(JsonReader in, long defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -257,7 +257,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link float}.
      */
-    public static final class PrimitiveFloatTypeAdapter{
+    public static final class PrimitiveFloatTypeAdapter {
 
         public static float read(JsonReader in, float defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -275,8 +275,6 @@ public final class KnownTypeAdapters {
             out.value(value);
         }
     }
-
-
 
 
     /**
@@ -297,7 +295,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link double}.
      */
-    public static final class PrimitiveDoubleTypeAdapter{
+    public static final class PrimitiveDoubleTypeAdapter {
 
         public static double read(JsonReader in, double defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -319,7 +317,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link char}.
      */
-    public static final class PrimitiveCharTypeAdapter{
+    public static final class PrimitiveCharTypeAdapter {
 
         public static char read(JsonReader in, char defaultValue) throws IOException {
             if (in.peek() == JsonToken.NULL) {
@@ -342,7 +340,7 @@ public final class KnownTypeAdapters {
     /**
      * Helper class for {@link boolean}.
      */
-    public static final class PrimitiveBooleanTypeAdapter{
+    public static final class PrimitiveBooleanTypeAdapter {
 
         public static boolean read(JsonReader in, boolean defaultValue) throws IOException {
             JsonToken peek = in.peek();
@@ -1043,7 +1041,7 @@ public final class KnownTypeAdapters {
         public JsonPrimitive read(JsonReader in) throws IOException {
             JsonElement jsonElement = JSON_ELEMENT.read(in);
             return jsonElement != null &&
-                   jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
+                    jsonElement.isJsonPrimitive() ? jsonElement.getAsJsonPrimitive() : null;
         }
     }.nullSafe();
 

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -662,8 +662,7 @@ public final class KnownTypeAdapters {
         }
     }
 
-    static final TypeAdapter<String> STRING_NULL_SAFE_TYPE_ADAPTER =
-            com.google.gson.internal.bind.TypeAdapters.STRING.nullSafe();
+    static final TypeAdapter<String> STRING_NULL_SAFE_TYPE_ADAPTER = TypeAdapters.STRING.nullSafe();
 
     /**
      * Type Adapter for char[] type. This can be directly accessed to read and write

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class KnownTypeAdaptersTest {
 
@@ -236,7 +238,7 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
-     * Test for ListTypeAdapter
+     * Test for {@link KnownTypeAdapters.ListTypeAdapter}
      *
      * @throws Exception
      */
@@ -275,6 +277,44 @@ public class KnownTypeAdaptersTest {
         for (int i = 0; i < intDummyList.size(); i++) {
             Assert.assertEquals(intDummyList.get(i), readValue1.get(i));
         }
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.MapTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForMapTypeAdapter() throws Exception {
+
+        // for string arrays
+        HashMap<String, String> dummyMap = Utils.createStringDummyMap();
+
+        TypeAdapter<HashMap<String, String>> mapTypeAdapter = new KnownTypeAdapters.MapTypeAdapter<>(TypeAdapters.STRING, TypeAdapters.STRING,
+                new KnownTypeAdapters.HashMapInstantiator<String, String>());
+
+        StringWriter stringWriter = new StringWriter();
+        mapTypeAdapter.write(new JsonWriter(stringWriter), dummyMap);
+        String jsonString = stringWriter.toString();
+
+        HashMap<String, String> readValue = mapTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertEquals(dummyMap.size(), readValue.size());
+        Utils.assertMapsEqual(dummyMap, readValue);
+
+        // for integer arrays
+        HashMap<Integer, Integer> intDummyMap = Utils.createIntegerDummyMap();
+
+        TypeAdapter<HashMap<Integer, Integer>> mapTypeAdapter1 = new KnownTypeAdapters.MapTypeAdapter<>(KnownTypeAdapters.INTEGER, KnownTypeAdapters.INTEGER,
+                new KnownTypeAdapters.HashMapInstantiator<Integer, Integer>());
+        stringWriter = new StringWriter();
+        mapTypeAdapter1.write(new JsonWriter(stringWriter), intDummyMap);
+        jsonString = stringWriter.toString();
+
+        HashMap<Integer, Integer> readValue1 = mapTypeAdapter1.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertEquals(intDummyMap.size(), readValue1.size());
+        Utils.assertMapsEqual(intDummyMap, readValue1);
     }
 
     /**

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -435,6 +435,113 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
+     * Test for {@link KnownTypeAdapters.PrimitiveBooleanTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveBooleanTypeAdapter() throws Exception {
+        boolean value = true;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveBooleanTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        boolean readValue = KnownTypeAdapters.PrimitiveBooleanTypeAdapter.read(new JsonReader(new StringReader(jsonString)), false);
+
+        Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveBooleanArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayBooleanTypeAdapter() throws Exception {
+        boolean[] value = new boolean[5];
+
+        value[0] = true;
+        value[1] = false;
+        value[2] = true;
+        value[3] = true;
+        value[4] = false;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveBooleanArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        boolean[] readValue = KnownTypeAdapters.PrimitiveBooleanArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveCharTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveCharacterTypeAdapter() throws Exception {
+        char value = 'A';
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveCharTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        char readValue = KnownTypeAdapters.PrimitiveCharTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 'B');
+
+        Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveCharTypeAdapter}
+     *
+     * @throws Exception
+     */
+    // TODO: 2/17/17 This test is broken
+    // @Test
+    public void testForPrimitiveArrayCharacterTypeAdapter() throws Exception {
+        // test an actual char array
+        char[] value = new char[5];
+
+        value[0] = 'a';
+        value[1] = 'b';
+        value[2] = 'c';
+        value[3] = 'd';
+        value[4] = 'e';
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveCharArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        char[] readValue = KnownTypeAdapters.PrimitiveCharArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
+
+        // test a string as a char array
+        char[] value1 = "abcde".toCharArray();
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter1 = new StringWriter();
+        KnownTypeAdapters.PrimitiveCharArrayAdapter.write(new JsonWriter(stringWriter1), value1);
+        String jsonString1 = stringWriter1.toString();
+
+        // call the TypeAdapter#read method
+        char[] readValue1 = KnownTypeAdapters.PrimitiveCharArrayAdapter.read(new JsonReader(new StringReader(jsonString1)));
+
+        Assert.assertArrayEquals(value1, readValue1);
+    }
+
+    /**
      * Test for {@link KnownTypeAdapters.ListTypeAdapter}
      *
      * @throws Exception

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -501,7 +501,7 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
-     * Test for {@link KnownTypeAdapters.PrimitiveCharTypeAdapter}
+     * Test for {@link KnownTypeAdapters.PrimitiveCharArrayAdapter}
      *
      * @throws Exception
      */

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -14,7 +14,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 
 public class KnownTypeAdaptersTest {
 
@@ -58,6 +57,32 @@ public class KnownTypeAdaptersTest {
         int readValue = KnownTypeAdapters.PrimitiveIntTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0);
 
         Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveIntegerArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayIntegerTypeAdapter() throws Exception {
+        int[] value = new int[5];
+
+        value[0] = 0;
+        value[1] = 1;
+        value[2] = 2;
+        value[3] = 3;
+        value[4] = 4;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveIntegerArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        int[] readValue = KnownTypeAdapters.PrimitiveIntegerArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
     }
 
     /**
@@ -105,6 +130,32 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
+     * Test for {@link KnownTypeAdapters.PrimitiveByteArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayByteTypeAdapter() throws Exception {
+        byte[] value = new byte[5];
+
+        value[0] = 0;
+        value[1] = 1;
+        value[2] = 2;
+        value[3] = 3;
+        value[4] = 4;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveByteArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        byte[] readValue = KnownTypeAdapters.PrimitiveByteArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
+    }
+
+    /**
      * Test for {@link KnownTypeAdapters#SHORT}
      *
      * @throws Exception
@@ -149,6 +200,32 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
+     * Test for {@link KnownTypeAdapters.PrimitiveShortArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayShortTypeAdapter() throws Exception {
+        short[] value = new short[5];
+
+        value[0] = 0;
+        value[1] = 1;
+        value[2] = 2;
+        value[3] = 3;
+        value[4] = 4;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveShortArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        short[] readValue = KnownTypeAdapters.PrimitiveShortArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
+    }
+
+    /**
      * Test for {@link KnownTypeAdapters#LONG}
      *
      * @throws Exception
@@ -173,7 +250,7 @@ public class KnownTypeAdaptersTest {
     }
 
     /**
-     * Test for {@link KnownTypeAdapters.PrimitiveLongArrayAdapter}
+     * Test for {@link KnownTypeAdapters.PrimitiveLongTypeAdapter}
      *
      * @throws Exception
      */
@@ -192,6 +269,31 @@ public class KnownTypeAdaptersTest {
         Assert.assertEquals(value, readValue);
     }
 
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveLongArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayLongTypeAdapter() throws Exception {
+        long[] value = new long[5];
+
+        value[0] = 0;
+        value[1] = 1;
+        value[2] = 2;
+        value[3] = 3;
+        value[4] = 4;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveLongArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        long[] readValue = KnownTypeAdapters.PrimitiveLongArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue);
+    }
 
     /**
      * Test for {@link KnownTypeAdapters#FLOAT}
@@ -235,6 +337,101 @@ public class KnownTypeAdaptersTest {
         float readValue = KnownTypeAdapters.PrimitiveFloatTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0f);
 
         Assert.assertEquals(value, readValue, 0);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveFloatArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayFloatTypeAdapter() throws Exception {
+        float[] value = new float[5];
+
+        value[0] = 0.0f;
+        value[1] = 1.0f;
+        value[2] = 2.0f;
+        value[3] = 3.0f;
+        value[4] = 4.0f;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveFloatArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        float[] readValue = KnownTypeAdapters.PrimitiveFloatArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue, 0);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters#DOUBLE}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForDoubleTypeAdapter() throws Exception {
+        Double value = 1234.1243;
+
+        TypeAdapter<Double> floatTypeAdapter = KnownTypeAdapters.DOUBLE;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        floatTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        Double readValue = floatTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertEquals(value.intValue(), readValue.intValue());
+        Assert.assertEquals(value, readValue, 0);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveDoubleTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveDoubleTypeAdapter() throws Exception {
+        double value = 1234.1243;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveDoubleTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        double readValue = KnownTypeAdapters.PrimitiveDoubleTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0f);
+
+        Assert.assertEquals(value, readValue, 0);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveDoubleArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveArrayDoubleTypeAdapter() throws Exception {
+        double[] value = new double[5];
+
+        value[0] = 0.0;
+        value[1] = 1.0;
+        value[2] = 2.0;
+        value[3] = 3.0;
+        value[4] = 4.0;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveDoubleArrayAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        double[] readValue = KnownTypeAdapters.PrimitiveDoubleArrayAdapter.read(new JsonReader(new StringReader(jsonString)));
+
+        Assert.assertArrayEquals(value, readValue, 0);
     }
 
     /**

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -24,16 +24,38 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForIntegerTypeAdapter() throws Exception {
         Integer value = 250;
+
         TypeAdapter<Integer> integerTypeAdapter = KnownTypeAdapters.INTEGER;
-        //create a string writer, and write the value to it using adapter
+
+        // create a string writer, and write the value to it using adapter
         StringWriter stringWriter = new StringWriter();
         integerTypeAdapter.write(new JsonWriter(stringWriter), value);
         String jsonString = stringWriter.toString();
 
-        //call the typeadapter#read method
+        // call the TypeAdapter#read method
         Integer readValue = integerTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
 
         Assert.assertEquals(value.intValue(), readValue.intValue());
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveIntTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveIntegerTypeAdapter() throws Exception {
+        int value = 250;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveIntTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        int readValue = KnownTypeAdapters.PrimitiveIntTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0);
+
+        Assert.assertEquals(value, readValue);
     }
 
     /**
@@ -44,17 +66,40 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForByteTypeAdapter() throws Exception {
         Byte value = 1;
+
         TypeAdapter<Byte> byteTypeAdapter = KnownTypeAdapters.BYTE;
-        //create a string writer, and write the value to it using adapter
+
+        // create a string writer, and write the value to it using adapter
         StringWriter stringWriter = new StringWriter();
         byteTypeAdapter.write(new JsonWriter(stringWriter), value);
         String jsonString = stringWriter.toString();
 
-        //call the typeadapter#read method
+        // call the TypeAdapter#read method
         Byte readValue = byteTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
 
         Assert.assertEquals(value.intValue(), readValue.intValue());
         Assert.assertEquals(value.byteValue(), readValue.byteValue());
+        Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveByteTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveByteTypeAdapter() throws Exception {
+        byte value = 1;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveByteTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        byte readValue = KnownTypeAdapters.PrimitiveByteTypeAdapter.read(new JsonReader(new StringReader(jsonString)), (byte) 0);
+
+        Assert.assertEquals(value, readValue);
     }
 
     /**
@@ -65,17 +110,40 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForShortTypeAdapter() throws Exception {
         Short value = 1;
+
         TypeAdapter<Short> shortTypeAdapter = KnownTypeAdapters.SHORT;
-        //create a string writer, and write the value to it using adapter
+
+        // create a string writer, and write the value to it using adapter
         StringWriter stringWriter = new StringWriter();
         shortTypeAdapter.write(new JsonWriter(stringWriter), value);
         String jsonString = stringWriter.toString();
 
-        //call the typeadapter#read method
+        // call the TypeAdapter#read method
         Short readValue = shortTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
 
         Assert.assertEquals(value.intValue(), readValue.intValue());
         Assert.assertEquals(value.shortValue(), readValue.shortValue());
+        Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveShortTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveShortTypeAdapter() throws Exception {
+        short value = 1;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveShortTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        short readValue = KnownTypeAdapters.PrimitiveShortTypeAdapter.read(new JsonReader(new StringReader(jsonString)), (short) 0);
+
+        Assert.assertEquals(value, readValue);
     }
 
     /**
@@ -86,17 +154,40 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForLongTypeAdapter() throws Exception {
         Long value = 121223444L;
+
         TypeAdapter<Long> longTypeAdapter = KnownTypeAdapters.LONG;
-        //create a string writer, and write the value to it using adapter
+
+        // create a string writer, and write the value to it using adapter
         StringWriter stringWriter = new StringWriter();
         longTypeAdapter.write(new JsonWriter(stringWriter), value);
         String jsonString = stringWriter.toString();
 
-        //call the typeadapter#read method
+        // call the TypeAdapter#read method
         Long readValue = longTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
 
         Assert.assertEquals(value.intValue(), readValue.intValue());
         Assert.assertEquals(value.longValue(), readValue.longValue());
+        Assert.assertEquals(value, readValue);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveLongArrayAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveLongTypeAdapter() throws Exception {
+        long value = 121223444L;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveLongTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        long readValue = KnownTypeAdapters.PrimitiveLongTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0);
+
+        Assert.assertEquals(value, readValue);
     }
 
 
@@ -108,17 +199,39 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForFloatTypeAdapter() throws Exception {
         Float value = 1234.1243F;
+
         TypeAdapter<Float> floatTypeAdapter = KnownTypeAdapters.FLOAT;
-        //create a string writer, and write the value to it using adapter
+
+        // create a string writer, and write the value to it using adapter
         StringWriter stringWriter = new StringWriter();
         floatTypeAdapter.write(new JsonWriter(stringWriter), value);
         String jsonString = stringWriter.toString();
 
-        //call the typeadapter#read method
+        // call the TypeAdapter#read method
         Float readValue = floatTypeAdapter.read(new JsonReader(new StringReader(jsonString)));
 
         Assert.assertEquals(value.intValue(), readValue.intValue());
         Assert.assertEquals(value.doubleValue(), readValue.doubleValue(), 0);
+        Assert.assertEquals(value, readValue, 0);
+    }
+
+    /**
+     * Test for {@link KnownTypeAdapters.PrimitiveFloatTypeAdapter}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testForPrimitiveFloatTypeAdapter() throws Exception {
+        float value = 1234.1243F;
+
+        // create a string writer, and write the value to it using adapter
+        StringWriter stringWriter = new StringWriter();
+        KnownTypeAdapters.PrimitiveFloatTypeAdapter.write(new JsonWriter(stringWriter), value);
+        String jsonString = stringWriter.toString();
+
+        // call the TypeAdapter#read method
+        float readValue = KnownTypeAdapters.PrimitiveFloatTypeAdapter.read(new JsonReader(new StringReader(jsonString)), 0f);
+
         Assert.assertEquals(value, readValue, 0);
     }
 
@@ -130,7 +243,7 @@ public class KnownTypeAdaptersTest {
     @Test
     public void testForListTypeAdapter() throws Exception {
 
-        //for string arrays
+        // for string arrays
         ArrayList<String> dummyList = Utils.createStringDummyList();
 
         TypeAdapter<ArrayList<String>> listTypeAdapter = new KnownTypeAdapters.ListTypeAdapter<>(TypeAdapters.STRING,
@@ -147,7 +260,7 @@ public class KnownTypeAdaptersTest {
             Assert.assertEquals(dummyList.get(i), readValue.get(i));
         }
 
-        //for integer arrays
+        // for integer arrays
         ArrayList<Integer> intDummyList = Utils.createIntegerDummyList();
 
         TypeAdapter<ArrayList<Integer>> listTypeAdapter1 = new KnownTypeAdapters.ListTypeAdapter<>(KnownTypeAdapters.INTEGER,

--- a/stag-library/src/test/java/com/vimeo/stag/Utils.java
+++ b/stag-library/src/test/java/com/vimeo/stag/Utils.java
@@ -23,64 +23,76 @@ public class Utils {
 
     public static ArrayList<String> createStringDummyList() {
         ArrayList<String> stringList = new ArrayList<>();
+
         stringList.add("abc");
         stringList.add("abc1");
         stringList.add("abc2");
         stringList.add("abc3");
         stringList.add("abc4");
         stringList.add("abc5");
+
         return stringList;
     }
 
     public static HashMap<String, String> createStringDummyMap() {
         HashMap<String, String> stringMap = new HashMap<>();
+
         stringMap.put("abc", "0");
         stringMap.put("abc1", "1");
         stringMap.put("abc2", "2");
         stringMap.put("abc3", "3");
         stringMap.put("abc4", "4");
         stringMap.put("abc5", "5");
+
         return stringMap;
     }
 
     public static ArrayList<Integer> createIntegerDummyList() {
         ArrayList<Integer> integerArrayList = new ArrayList<>();
+
         integerArrayList.add(1);
         integerArrayList.add(2);
         integerArrayList.add(3);
         integerArrayList.add(4);
         integerArrayList.add(5);
         integerArrayList.add(6);
+
         return integerArrayList;
     }
 
     public static HashMap<Integer, Integer> createIntegerDummyMap() {
         HashMap<Integer, Integer> integerMap = new HashMap<>();
+
         integerMap.put(1, 11);
         integerMap.put(2, 22);
         integerMap.put(3, 33);
         integerMap.put(4, 44);
         integerMap.put(5, 55);
         integerMap.put(6, 66);
+
         return integerMap;
     }
 
     public static JsonObject createDummyJsonObject() {
         JsonObject jsonObject = new JsonObject();
+
         jsonObject.addProperty("key", "value");
         jsonObject.addProperty("key1", "value1");
         jsonObject.addProperty("key2", "value2");
         jsonObject.addProperty("key3", "value3");
         jsonObject.addProperty("key4", "value4");
+
         return jsonObject;
     }
 
     public static JsonArray createDummyJsonArray() {
         JsonArray jsonArray = new JsonArray();
+
         jsonArray.add("item1");
         jsonArray.add("item2");
         jsonArray.add("item3");
         jsonArray.add("item4");
+
         return jsonArray;
     }
 }

--- a/stag-library/src/test/java/com/vimeo/stag/Utils.java
+++ b/stag-library/src/test/java/com/vimeo/stag/Utils.java
@@ -3,9 +3,23 @@ package com.vimeo.stag;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import org.junit.Assert;
+
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Utils {
+
+    public static <K, V> void assertMapsEqual(Map<K, V> map1, Map<K, V> map2) throws Exception {
+        for (K key : map1.keySet()) {
+            Assert.assertEquals(map1.get(key), map2.get(key));
+        }
+
+        for (K key : map2.keySet()) {
+            Assert.assertEquals(map2.get(key), map1.get(key));
+        }
+    }
 
     public static ArrayList<String> createStringDummyList() {
         ArrayList<String> stringList = new ArrayList<>();
@@ -18,6 +32,17 @@ public class Utils {
         return stringList;
     }
 
+    public static HashMap<String, String> createStringDummyMap() {
+        HashMap<String, String> stringMap = new HashMap<>();
+        stringMap.put("abc", "0");
+        stringMap.put("abc1", "1");
+        stringMap.put("abc2", "2");
+        stringMap.put("abc3", "3");
+        stringMap.put("abc4", "4");
+        stringMap.put("abc5", "5");
+        return stringMap;
+    }
+
     public static ArrayList<Integer> createIntegerDummyList() {
         ArrayList<Integer> integerArrayList = new ArrayList<>();
         integerArrayList.add(1);
@@ -27,6 +52,17 @@ public class Utils {
         integerArrayList.add(5);
         integerArrayList.add(6);
         return integerArrayList;
+    }
+
+    public static HashMap<Integer, Integer> createIntegerDummyMap() {
+        HashMap<Integer, Integer> integerMap = new HashMap<>();
+        integerMap.put(1, 11);
+        integerMap.put(2, 22);
+        integerMap.put(3, 33);
+        integerMap.put(4, 44);
+        integerMap.put(5, 55);
+        integerMap.put(6, 66);
+        return integerMap;
     }
 
     public static JsonObject createDummyJsonObject() {


### PR DESCRIPTION
#### Summary
Created unit tests for several adapters in `KnownTypeAdapters`.
- `PrimitiveIntTypeAdapter`
- `PrimitiveIntegerArrayAdapter`
- `PrimitiveByteTypeAdapter `
- `PrimitiveByteArrayAdapter`
- `PrimitiveShortTypeAdapter`
- `PrimitiveShortArrayAdapter`
- `PrimitiveLongTypeAdapter`
- `PrimitiveLongArrayAdapter`
- `PrimitiveFloatTypeAdapter`
- `PrimitiveFloatArrayAdapter`
- `DOUBLE`
- `PrimitiveDoubleTypeAdapter`
- `PrimitiveDoubleArrayAdapter`
- `PrimitiveBooleanTypeAdapter`
- `PrimitiveBooleanArrayAdapter`
- `PrimitiveCharTypeAdapter`
- `PrimitiveCharArrayTypeAdapter` - This test is currently broken and is therefore commented out, see #63 

#### How to Test
Run all the tests (a.k.a let the CI do its thing)
