### PR TITLE
Suppress rawtypes warnings in generated code

### DIFF
--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -50,6 +50,6 @@ apt {
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Werror"
+        options.compilerArgs << "-Xlint:all,-deprecation,-serial,-processing" << "-Werror"
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -54,6 +54,6 @@ apt {
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Werror"
+        options.compilerArgs << "-Xlint:all,-deprecation,-serial,-processing" << "-Werror"
     }
 }

--- a/sample/src/main/java/com/vimeo/sample/MainActivity.java
+++ b/sample/src/main/java/com/vimeo/sample/MainActivity.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity {
 
     private final List<Video> mVideoList = new ArrayList<>();
-    private ArrayAdapter mAdapter;
+    private ArrayAdapter<?> mAdapter;
     private NetworkRequest mRequest;
 
     @Override

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -39,7 +39,6 @@ import com.squareup.javapoet.TypeVariableName;
 import com.vimeo.stag.processor.generators.model.AnnotatedClass;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
 import com.vimeo.stag.processor.generators.model.SupportedTypesModel;
-import com.vimeo.stag.processor.utils.ElementUtils;
 import com.vimeo.stag.processor.utils.FileGenUtils;
 import com.vimeo.stag.processor.utils.KnownTypeAdapterUtils;
 import com.vimeo.stag.processor.utils.Preconditions;
@@ -62,7 +61,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -312,6 +310,7 @@ public class StagGenerator {
                 .addAnnotation(Override.class)
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
                         .addMember("value", "\"unchecked\"")
+                        .addMember("value", "\"rawtypes\"")
                         .build())
                 .addTypeVariable(genericTypeName)
                 .returns(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), genericTypeName))

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -34,7 +34,6 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
-import com.vimeo.stag.KnownTypeAdapters;
 import com.vimeo.stag.KnownTypeAdapters.ArrayTypeAdapter;
 import com.vimeo.stag.KnownTypeAdapters.ListTypeAdapter;
 import com.vimeo.stag.KnownTypeAdapters.MapTypeAdapter;
@@ -722,6 +721,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder()
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
                                        .addMember("value", "\"unchecked\"")
+                                       .addMember("value", "\"rawtypes\"")
                                        .build())
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(Gson.class, "gson")


### PR DESCRIPTION
#### Ticket Summary

Expands the warning suppressions in the generated code to include "rawtypes".

#### Implementation Summary

All warnings except for "deprecation", "serial", and "processor" are now treated as errors.

#### How to Test

Comment out the `.addMember("value", "\"rawtypes\"")` lines in the change set and rebuild
the project.  The result will be compilation errors (i.e., warnings promoted to error status).
