### PR TITLE
@JsonAdapter Support added

### DIFF
--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 apt {
     arguments {
         stagGeneratedPackageName "com.vimeo.sample_model.stag.generated"
-        stagDebug false
+        stagDebug true
     }
 }
 

--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
 apt {
     arguments {
-        stagGeneratedPackageName "com.vimeo.sample.sample_model.stag.generated"
+        stagGeneratedPackageName "com.vimeo.sample_model.stag.generated"
         stagDebug false
     }
 }

--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 apt {
     arguments {
         stagGeneratedPackageName "com.vimeo.sample.sample_model.stag.generated"
-        stagDebug true
+        stagDebug false
     }
 }
 

--- a/sample-model/src/test/java/com/vimeo/sample_model/Utils.java
+++ b/sample-model/src/test/java/com/vimeo/sample_model/Utils.java
@@ -6,7 +6,7 @@ import android.support.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
-import com.vimeo.sample.sample_model.stag.generated.Stag;
+import com.vimeo.sample_model.stag.generated.Stag;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 apt {
     arguments {
         stagGeneratedPackageName "com.vimeo.sample.stag.generated"
-        stagDebug false
+        stagDebug true
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 apt {
     arguments {
         stagGeneratedPackageName "com.vimeo.sample.stag.generated"
-        stagDebug true
+        stagDebug false
     }
 }
 

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -30,4 +30,8 @@ public class JsonAdapterExample {
     @SerializedName("user")
     @JsonAdapter(value =  TestSerializer.class)
     public User user;
+
+    @SerializedName("user1")
+    @JsonAdapter(value =  TestSerializer.class)
+    public User user1;
 }

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -1,5 +1,7 @@
 package com.vimeo.sample.model;
 
+import android.support.annotation.NonNull;
+
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.vimeo.stag.UseStag;
@@ -11,6 +13,7 @@ public class JsonAdapterExample {
 
     @SerializedName("created_time")
     @JsonAdapter(value = DateParser.class, nullSafe = true)
+    @NonNull
     public Date mCreatedTime;
 
     @SerializedName("accessed_time")
@@ -32,6 +35,10 @@ public class JsonAdapterExample {
     public User user;
 
     @SerializedName("user1")
-    @JsonAdapter(value =  TestSerializer.class)
+    @JsonAdapter(value =  TestDeserializer.class)
     public User user1;
+
+    @SerializedName("user2")
+    @JsonAdapter(value =  TestSerializerDeserializer.class)
+    public User user2;
 }

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -1,0 +1,29 @@
+package com.vimeo.sample.model;
+
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+import java.util.Date;
+
+@UseStag
+public class JsonAdapterExample {
+
+    @SerializedName("created_time")
+    @JsonAdapter(value = DateParser.class, nullSafe = true)
+    public Date mCreatedTime;
+
+    @SerializedName("accessed_time")
+    @JsonAdapter(value = DateParser.class, nullSafe = false)
+    public Date mAccessedTime;
+
+
+    @SerializedName("alternate_model")
+    @JsonAdapter(value = com.vimeo.sample.sample_model.stag.generated.Stag.Factory.class)
+    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
+
+
+    @SerializedName("alternate_model1")
+    @JsonAdapter(value = com.vimeo.sample_model.AlternateNameModel$TypeAdapter.class)
+    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample1;
+}

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -19,11 +19,15 @@ public class JsonAdapterExample {
 
 
     @SerializedName("alternate_model")
-    @JsonAdapter(value = com.vimeo.sample_model.stag.generated.Stag.Factory.class, nullSafe = false)
+    @JsonAdapter(value = com.vimeo.sample_model.stag.generated.Stag.Factory.class)
     public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
 
 
     @SerializedName("alternate_model1")
     @JsonAdapter(value = com.vimeo.sample_model.AlternateNameModel$TypeAdapter.class)
     public com.vimeo.sample_model.AlternateNameModel mRunTimeExample1;
+
+    @SerializedName("user")
+    @JsonAdapter(value =  TestSerializer.class)
+    public User user;
 }

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -18,9 +18,9 @@ public class JsonAdapterExample {
     public Date mAccessedTime;
 
 
-//    @SerializedName("alternate_model")
-//    @JsonAdapter(value = com.vimeo.sample.sample_model.stag.generated.Stag.Factory.class)
-//    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
+    @SerializedName("alternate_model")
+    @JsonAdapter(value = com.vimeo.sample_model.stag.generated.Stag.Factory.class, nullSafe = false)
+    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
 
 
     @SerializedName("alternate_model1")

--- a/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/JsonAdapterExample.java
@@ -18,9 +18,9 @@ public class JsonAdapterExample {
     public Date mAccessedTime;
 
 
-    @SerializedName("alternate_model")
-    @JsonAdapter(value = com.vimeo.sample.sample_model.stag.generated.Stag.Factory.class)
-    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
+//    @SerializedName("alternate_model")
+//    @JsonAdapter(value = com.vimeo.sample.sample_model.stag.generated.Stag.Factory.class)
+//    public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;
 
 
     @SerializedName("alternate_model1")

--- a/sample/src/main/java/com/vimeo/sample/model/TestDeserializer.java
+++ b/sample/src/main/java/com/vimeo/sample/model/TestDeserializer.java
@@ -1,0 +1,19 @@
+package com.vimeo.sample.model;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+/**
+ * Created by anshul.garg on 08/03/17.
+ */
+
+public class TestDeserializer implements JsonDeserializer<User> {
+    @Override
+    public User deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return context.deserialize(json, User.class);
+    }
+}

--- a/sample/src/main/java/com/vimeo/sample/model/TestSerializer.java
+++ b/sample/src/main/java/com/vimeo/sample/model/TestSerializer.java
@@ -1,0 +1,30 @@
+package com.vimeo.sample.model;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Created by anshul.garg on 02/03/17.
+ */
+
+public class TestSerializer implements JsonDeserializer<User> , JsonSerializer<User>{
+    @Override
+    public User deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return context.deserialize(json,User.class);
+    }
+
+    @Override
+    public JsonElement serialize(User src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject result = null;
+        result.add("location", context.serialize(src.mLocation + "test"));
+        result.add("name", context.serialize(src.mName + "TestName"));
+        return result;
+    }
+}

--- a/sample/src/main/java/com/vimeo/sample/model/TestSerializerDeserializer.java
+++ b/sample/src/main/java/com/vimeo/sample/model/TestSerializerDeserializer.java
@@ -1,17 +1,24 @@
 package com.vimeo.sample.model;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
 
 /**
- * Created by anshul.garg on 02/03/17.
+ * Created by anshul.garg on 08/03/17.
  */
 
-public class TestSerializer implements JsonSerializer<User> {
+public class TestSerializerDeserializer implements JsonDeserializer<User>, JsonSerializer<User> {
+    @Override
+    public User deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return context.deserialize(json, User.class);
+    }
 
     @Override
     public JsonElement serialize(User src, Type typeOfSrc, JsonSerializationContext context) {

--- a/sample/src/main/java/com/vimeo/sample/model/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model/Video.java
@@ -23,7 +23,9 @@
  */
 package com.vimeo.sample.model;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.internal.bind.DateTypeAdapter;
 import com.vimeo.stag.UseStag;
 
 import java.util.Date;
@@ -46,6 +48,7 @@ public class Video {
     public String mName;
 
     @SerializedName("created_time")
+    @JsonAdapter(value = DateParser.class, nullSafe = true)
     public Date mCreatedTime;
 
     @SerializedName("stats")

--- a/sample/src/main/java/com/vimeo/sample/model/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model/Video.java
@@ -48,7 +48,6 @@ public class Video {
     public String mName;
 
     @SerializedName("created_time")
-    @JsonAdapter(value = DateParser.class, nullSafe = true)
     public Date mCreatedTime;
 
     @SerializedName("stats")

--- a/sample/src/main/java/com/vimeo/sample/model1/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model1/Video.java
@@ -2,7 +2,10 @@ package com.vimeo.sample.model1;
 
 import android.support.annotation.NonNull;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.internal.bind.DateTypeAdapter;
+import com.google.gson.internal.bind.ReflectiveTypeAdapterFactory;
 import com.vimeo.sample.model.User;
 import com.vimeo.stag.UseStag;
 
@@ -27,5 +30,6 @@ public class Video {
 
     @NonNull
     @SerializedName("mData")
+    @JsonAdapter(value = ReflectiveTypeAdapterFactory.class)
     public Data mData;
 }

--- a/sample/src/main/java/com/vimeo/sample/model1/Video.java
+++ b/sample/src/main/java/com/vimeo/sample/model1/Video.java
@@ -30,6 +30,5 @@ public class Video {
 
     @NonNull
     @SerializedName("mData")
-    @JsonAdapter(value = ReflectiveTypeAdapterFactory.class)
     public Data mData;
 }

--- a/sample/src/test/java/com/vimeo/sample/model/JsonAdapterExampleTest.java
+++ b/sample/src/test/java/com/vimeo/sample/model/JsonAdapterExampleTest.java
@@ -1,0 +1,15 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.sample.Utils;
+
+import org.junit.Test;
+
+/**
+ * Created by anshul.garg on 03/03/17.
+ */
+public class JsonAdapterExampleTest {
+    @Test
+    public void typeAdapterWasGenerated() throws Exception {
+        Utils.verifyTypeAdapterGeneration(JsonAdapterExample.class);
+    }
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -624,7 +624,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 catch( MirroredTypeException mte )
                 {
                     jsonAdapterType = mte.getTypeMirror();
-                    jsonAdapterTypeElement = TypeUtils.getUtils().asElement(jsonAdapterType);
+                    jsonAdapterTypeElement = TypeUtils.getElementFromTypeMirror(jsonAdapterType);
                     TypeUtils.JsonAdapterType jsonAdapterType1 = TypeUtils.getJsonAdapterType(jsonAdapterType);
                     for(Element element : jsonAdapterTypeElement.getEnclosedElements()) {
                         if (element instanceof ExecutableElement) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -276,11 +275,11 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
             if(isPrimitive) {
                 builder.addCode("\t\t\t\tobject." + variableName + " = " +
-                        adapterFieldInfo.getAdapterAccessor(elementValue) + ".read(reader, object." + variableName +  ");");
+                        adapterFieldInfo.getAdapterAccessor(elementValue, name) + ".read(reader, object." + variableName +  ");");
 
             } else {
                 builder.addCode("\t\t\t\tobject." + variableName + " = " +
-                        adapterFieldInfo.getAdapterAccessor(elementValue) + ".read(reader);");
+                        adapterFieldInfo.getAdapterAccessor(elementValue, name) + ".read(reader);");
             }
 
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -42,7 +42,6 @@ import com.vimeo.stag.KnownTypeAdapters.ObjectTypeAdapter;
 import com.vimeo.stag.processor.generators.model.AnnotatedClass;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
 import com.vimeo.stag.processor.generators.model.SupportedTypesModel;
-import com.vimeo.stag.processor.utils.ElementUtils;
 import com.vimeo.stag.processor.utils.FileGenUtils;
 import com.vimeo.stag.processor.utils.KnownTypeAdapterUtils;
 import com.vimeo.stag.processor.utils.TypeUtils;
@@ -54,12 +53,10 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -612,6 +609,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             TypeMirror fieldType = entry.getValue();
             JsonAdapter annotation = entry.getKey().getAnnotation(JsonAdapter.class);
             String adapterAccessor;
+            TypeUtils.JsonAdapterType jsonAdapterType1 = TypeUtils.JsonAdapterType.NONE;
             if(null != annotation) {
                 TypeMirror jsonAdapterType = null;
                 Element jsonAdapterTypeElement = null;
@@ -625,7 +623,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 {
                     jsonAdapterType = mte.getTypeMirror();
                     jsonAdapterTypeElement = TypeUtils.getElementFromTypeMirror(jsonAdapterType);
-                    TypeUtils.JsonAdapterType jsonAdapterType1 = TypeUtils.getJsonAdapterType(jsonAdapterType);
+                    jsonAdapterType1 = TypeUtils.getJsonAdapterType(jsonAdapterType);
                     for(Element element : jsonAdapterTypeElement.getEnclosedElements()) {
                         if (element instanceof ExecutableElement) {
                             ExecutableElement executableElement =

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -924,10 +924,10 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
         String getAdapterAccessor(@NotNull TypeMirror typeMirror, @NotNull String fieldName) {
             String adapterAccessor = mFieldAdapterAccessor.get(fieldName);
-            if (adapterAccessor != null) {
-                return adapterAccessor;
+            if (adapterAccessor == null) {
+                adapterAccessor = mAdapterAccessor.get(typeMirror.toString());
             }
-            return mAdapterAccessor.get(typeMirror.toString());
+            return adapterAccessor;
         }
 
         String getFieldName(@NotNull TypeMirror fieldType) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -332,11 +332,11 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         }
     }
 
-    private String getAdapterAccessorForKnownJsonAdapterType(@NotNull ExecutableElement adapterType, @NotNull TypeSpec.Builder adapterBuilder,
-                                                             @NotNull MethodSpec.Builder constructorBuilder,
-                                                             @NotNull TypeMirror fieldType,
-                                                             @NotNull TypeUtils.JsonAdapterType jsonAdapterType, @NotNull AdapterFieldInfo adapterFieldInfo, boolean isNullSafe,
-                                                             @NotNull String keyFieldName) {
+    private String getFieldAccessorForKnownJsonAdapterType(@NotNull ExecutableElement adapterType, @NotNull TypeSpec.Builder adapterBuilder,
+                                                           @NotNull MethodSpec.Builder constructorBuilder,
+                                                           @NotNull TypeMirror fieldType,
+                                                           @NotNull TypeUtils.JsonAdapterType jsonAdapterType, @NotNull AdapterFieldInfo adapterFieldInfo, boolean isNullSafe,
+                                                           @NotNull String keyFieldName) {
         String fieldAdapterAccessor = "new " + FileGenUtils.escapeStringForCodeBlock(adapterType.getEnclosingElement().toString());
         if (jsonAdapterType == TypeUtils.JsonAdapterType.TYPE_ADAPTER) {
             ArrayList<String> constructorParameters = new ArrayList<>();
@@ -398,9 +398,8 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             statement += ".nullSafe()";
         }
         constructorBuilder.addStatement(statement);
-        fieldAdapterAccessor = fieldName;
 
-        return fieldAdapterAccessor;
+        return fieldName;
     }
     /**
      * Returns the adapter code for the known types.
@@ -707,7 +706,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                                     ((ExecutableElement) element);
                             Name name = executableElement.getSimpleName();
                             if (name.contentEquals("<init>")) {
-                                String fieldAdapterAccessor = getAdapterAccessorForKnownJsonAdapterType(executableElement, adapterBuilder, constructorBuilder, fieldType,
+                                String fieldAdapterAccessor = getFieldAccessorForKnownJsonAdapterType(executableElement, adapterBuilder, constructorBuilder, fieldType,
                                         jsonAdapterType1, result, annotation.nullSafe(), getJsonName(entry.getKey()));
                                 result.addFieldToAccessor(getJsonName(entry.getKey()), fieldAdapterAccessor);
                             }
@@ -946,7 +945,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             mAdapterAccessor.put(typeMirror.toString(), accessorCode);
         }
 
-        void addFieldToAccessor(@NotNull String  fieldName, String accessorCode){
+        void addFieldToAccessor(@NotNull String  fieldName, @NotNull String accessorCode){
             mFieldAdapterAccessor.put(fieldName, accessorCode);
         }
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -632,7 +632,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                                     ((ExecutableElement) element);
                             Name name = executableElement.getSimpleName();
                             if (name.contentEquals("<init>")) {
-                                System.out.println("Yasir : " + fieldType.toString() + " " + executableElement.toString() + " jsonAdapterType1 : " + jsonAdapterType1.name());
+                                System.out.println("Yasir : " + fieldType.toString() + " " + executableElement.toString() + " jsonAdapterType1 : " + jsonAdapterType1.name() );
                             }
                         }
                     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -28,6 +28,8 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
@@ -86,4 +88,20 @@ public final class ElementUtils {
         return elementKind == ElementKind.CLASS || elementKind == ElementKind.ENUM;
     }
 
+    @Nullable
+    public static ExecutableElement getFirstConstructor(@Nullable TypeMirror typeMirror) {
+        if(typeMirror != null) {
+            Element typeElement = TypeUtils.getElementFromTypeMirror(typeMirror);
+            for (Element element : typeElement.getEnclosedElements()) {
+                if (element instanceof ExecutableElement) {
+                    ExecutableElement executableElement = ((ExecutableElement) element);
+                    Name name = executableElement.getSimpleName();
+                    if (name.contentEquals("<init>")) {
+                        return executableElement;
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -27,7 +27,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.annotations.JsonAdapter;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,6 +47,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Types;
 
 public final class TypeUtils {
@@ -554,7 +554,11 @@ public final class TypeUtils {
      * @return {@link JsonAdapterType}
      */
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
-        if(sTypeUtils.isSubtype(type, ElementUtils.getTypeFromQualifiedName(TypeAdapter.class.getName()))) {
+        WildcardType WILDCARD_TYPE_NULL = sTypeUtils.getWildcardType(null, null);
+        TypeMirror[] typex = {WILDCARD_TYPE_NULL};
+        final TypeElement typeAdapterElement = ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName());
+        DeclaredType typeAdapter = sTypeUtils.getDeclaredType(typeAdapterElement, typex);
+        if(sTypeUtils.isSubtype(type, typeAdapter)) {
             return JsonAdapterType.TYPE_ADAPTER;
         } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER_FACTORY;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -554,7 +554,6 @@ public final class TypeUtils {
      * @return {@link JsonAdapterType}
      */
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
-        System.out.println("type : " + );
         if(sTypeUtils.isSubtype(type, ElementUtils.getTypeFromQualifiedName(TypeAdapter.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER;
         } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -574,21 +574,22 @@ public final class TypeUtils {
      * @param type :TypeMirror type
      * @return {@link JsonAdapterType}
      */
+    @NotNull
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
-        WildcardType WILDCARD_TYPE_NULL = sTypeUtils.getWildcardType(null, null);
-        TypeMirror[] typex = {WILDCARD_TYPE_NULL};
-        if(sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName()), typex))) {
+        WildcardType wildcardType = sTypeUtils.getWildcardType(null, null);
+        TypeMirror[] typex = {wildcardType};
+        if (sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName()), typex))) {
             return JsonAdapterType.TYPE_ADAPTER;
-        } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
+        } else if (sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER_FACTORY;
         } else {
             boolean isDeserializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonDeserializer.class.getName()), typex));
             boolean isSerializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonSerializer.class.getName()), typex));
-            if(isSerializer && isDeserializer) {
+            if (isSerializer && isDeserializer) {
                 return JsonAdapterType.JSON_SERIALIZER_DESERIALIZER;
-            } else if(isSerializer) {
+            } else if (isSerializer) {
                 return JsonAdapterType.JSON_SERIALIZER;
-            } else if(isDeserializer) {
+            } else if (isDeserializer) {
                 return JsonAdapterType.JSON_DESERIALIZER;
             } else {
                 return JsonAdapterType.NONE;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -554,6 +554,7 @@ public final class TypeUtils {
      * @return {@link JsonAdapterType}
      */
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
+        System.out.println("type : " + );
         if(sTypeUtils.isSubtype(type, ElementUtils.getTypeFromQualifiedName(TypeAdapter.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER;
         } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -23,6 +23,12 @@
  */
 package com.vimeo.stag.processor.utils;
 
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -509,5 +515,41 @@ public final class TypeUtils {
     public static TypeMirror getArrayInnerType(@NotNull TypeMirror type) {
         return (type instanceof ArrayType) ? ((ArrayType) type).getComponentType() : ((DeclaredType) type).getTypeArguments()
                 .get(0);
+    }
+
+
+    public static enum JsonAdapterType {
+        NONE,
+        TYPE_ADAPTER,
+        TYPE_ADAPTER_FACTORY,
+        JSON_SERIALIZER,
+        JSON_DESERIALIZER,
+        JSON_SERIALIZER_DESERIALIZER
+
+    }
+    /**
+     * Return the type of JsonAdapter {@link TypeMirror}
+     *
+     * @param type :TypeMirror type
+     * @return {@link JsonAdapterType}
+     */
+    public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
+        if(sTypeUtils.isSubtype(type, ElementUtils.getTypeFromQualifiedName(TypeAdapter.class.getName()))) {
+            return JsonAdapterType.TYPE_ADAPTER;
+        } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
+            return JsonAdapterType.TYPE_ADAPTER_FACTORY;
+        } else {
+            boolean isDeserializer = sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(JsonDeserializer.class.getName()));
+            boolean isSerializer = sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(JsonSerializer.class.getName()));
+            if(isSerializer && isDeserializer) {
+                return JsonAdapterType.JSON_SERIALIZER_DESERIALIZER;
+            } else if(isSerializer) {
+                return JsonAdapterType.JSON_SERIALIZER;
+            } else if(isDeserializer) {
+                return JsonAdapterType.JSON_DESERIALIZER;
+            } else {
+                return JsonAdapterType.NONE;
+            }
+        }
     }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -577,15 +577,13 @@ public final class TypeUtils {
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
         WildcardType WILDCARD_TYPE_NULL = sTypeUtils.getWildcardType(null, null);
         TypeMirror[] typex = {WILDCARD_TYPE_NULL};
-        final TypeElement typeAdapterElement = ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName());
-        DeclaredType typeAdapter = sTypeUtils.getDeclaredType(typeAdapterElement, typex);
-        if(sTypeUtils.isSubtype(type, typeAdapter)) {
+        if(sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName()), typex))) {
             return JsonAdapterType.TYPE_ADAPTER;
         } else if(sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER_FACTORY;
         } else {
-            boolean isDeserializer = sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(JsonDeserializer.class.getName()));
-            boolean isSerializer = sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(JsonSerializer.class.getName()));
+            boolean isDeserializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonDeserializer.class.getName()), typex));
+            boolean isSerializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonSerializer.class.getName()), typex));
             if(isSerializer && isDeserializer) {
                 return JsonAdapterType.JSON_SERIALIZER_DESERIALIZER;
             } else if(isSerializer) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -576,15 +576,13 @@ public final class TypeUtils {
      */
     @NotNull
     public static JsonAdapterType getJsonAdapterType(@NotNull TypeMirror type) {
-        WildcardType wildcardType = sTypeUtils.getWildcardType(null, null);
-        TypeMirror[] typex = {wildcardType};
-        if (sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(TypeAdapter.class.getName()), typex))) {
+        if (sTypeUtils.isSubtype(type, getDeclaredTypeForParameterizedClass(TypeAdapter.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER;
         } else if (sTypeUtils.isAssignable(type, ElementUtils.getTypeFromQualifiedName(TypeAdapterFactory.class.getName()))) {
             return JsonAdapterType.TYPE_ADAPTER_FACTORY;
         } else {
-            boolean isDeserializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonDeserializer.class.getName()), typex));
-            boolean isSerializer = sTypeUtils.isSubtype(type, sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(JsonSerializer.class.getName()), typex));
+            boolean isDeserializer = sTypeUtils.isSubtype(type, getDeclaredTypeForParameterizedClass(JsonDeserializer.class.getName()));
+            boolean isSerializer = sTypeUtils.isSubtype(type, getDeclaredTypeForParameterizedClass(JsonSerializer.class.getName()));
             if (isSerializer && isDeserializer) {
                 return JsonAdapterType.JSON_SERIALIZER_DESERIALIZER;
             } else if (isSerializer) {
@@ -597,7 +595,14 @@ public final class TypeUtils {
         }
     }
 
-    public static boolean isAssignable(TypeMirror t1, TypeMirror t2){
-        return sTypeUtils.isAssignable(t1,t2);
+    public static boolean isAssignable(TypeMirror t1, TypeMirror t2) {
+        return sTypeUtils.isAssignable(t1, t2);
+    }
+
+    @NotNull
+    public static DeclaredType getDeclaredTypeForParameterizedClass(@NotNull String className) {
+        WildcardType wildcardType = sTypeUtils.getWildcardType(null, null);
+        TypeMirror[] typex = {wildcardType};
+        return sTypeUtils.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(className), typex);
     }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -65,7 +65,7 @@ public final class TypeUtils {
     }
 
     @NotNull
-    private static Types getUtils() {
+    public static Types getUtils() {
         Preconditions.checkNotNull(sTypeUtils);
         return sTypeUtils;
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -79,7 +79,7 @@ public final class TypeUtils {
     }
 
     @NotNull
-    public static Types getUtils() {
+    private static Types getUtils() {
         Preconditions.checkNotNull(sTypeUtils);
         return sTypeUtils;
     }
@@ -559,7 +559,7 @@ public final class TypeUtils {
     }
 
 
-    public static enum JsonAdapterType {
+    public enum JsonAdapterType {
         NONE,
         TYPE_ADAPTER,
         TYPE_ADAPTER_FACTORY,
@@ -594,5 +594,9 @@ public final class TypeUtils {
                 return JsonAdapterType.NONE;
             }
         }
+    }
+
+    public static boolean isAssignable(TypeMirror t1, TypeMirror t2){
+        return sTypeUtils.isAssignable(t1,t2);
     }
 }

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.java
@@ -23,9 +23,8 @@
  */
 package com.vimeo.stag.processor;
 
-import com.vimeo.stag.processor.dummy.DummyAbstractClass;
+import com.vimeo.stag.processor.dummy.DummyClassWithConstructor;
 import com.vimeo.stag.processor.dummy.DummyConcreteClass;
-import com.vimeo.stag.processor.dummy.DummyEnumClass;
 import com.vimeo.stag.processor.dummy.DummyGenericClass;
 import com.vimeo.stag.processor.dummy.DummyInheritedClass;
 import com.vimeo.stag.processor.utils.ElementUtils;
@@ -38,7 +37,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 
 public class ElementUtilsUnitTest extends BaseUnitTest {
 
@@ -101,6 +100,23 @@ public class ElementUtilsUnitTest extends BaseUnitTest {
                 ElementUtils.getPackage(Utils.getTypeMirrorFromClass(String.class)));
         Assert.assertNotEquals(DummyInheritedClass.class.getPackage().getName(),
                 ElementUtils.getPackage(Utils.getTypeMirrorFromClass(Object.class)));
+    }
+
+    @Test
+    public void testGetConstructor() throws Exception {
+        ExecutableElement executableElement = ElementUtils.getFirstConstructor(Utils.getTypeMirrorFromClass(String.class));
+        Assert.assertEquals(executableElement.getEnclosingElement().toString(),Utils.getElementFromClass(String.class).toString());
+        Assert.assertEquals(executableElement.getParameters().size(), 0);
+
+        executableElement = ElementUtils.getFirstConstructor(Utils.getTypeMirrorFromClass(DummyClassWithConstructor.class));
+        Assert.assertEquals(executableElement.getEnclosingElement().toString(),Utils.getElementFromClass(DummyClassWithConstructor.class).toString());
+        Assert.assertEquals(executableElement.getParameters().size(), 1);
+        Assert.assertEquals(executableElement.getParameters().get(0).asType().toString(), Utils.getElementFromClass(String.class).toString());
+
+        executableElement = ElementUtils.getFirstConstructor(Utils.getTypeMirrorFromClass(DummyGenericClass.class));
+        Assert.assertEquals(executableElement.getEnclosingElement().toString(), Utils.getElementFromClass(DummyGenericClass.class).toString());
+        Assert.assertEquals(executableElement.getParameters().size(), 0);
+
     }
 
 }

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyClassWithConstructor.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyClassWithConstructor.java
@@ -1,0 +1,16 @@
+package com.vimeo.stag.processor.dummy;
+
+/**
+ * Created by anshul.garg on 09/03/17.
+ */
+
+public class DummyClassWithConstructor {
+    public String string;
+
+    public DummyClassWithConstructor(String string) {
+        this.string = string;
+    }
+
+    public DummyClassWithConstructor() {
+    }
+}


### PR DESCRIPTION
#### Ticket Summary
Added support for [@JsonAdapter](https://google.github.io/gson/apidocs/com/google/gson/annotations/JsonAdapter.html) for field level. 

#### Implementation Summary
1. Added Util function in "TypeUtils" class to get JsonAdapterType (can be TypeAdapater, TypeAdapterFactory, Serializer, Deserializer, SerializerDeserializer) given in JsonAdapterKey annotation. JsonAdapterType is , if value class of JsonAdapterKey :

        1. Is subtype of TypeAdapter then  TYPE_ADAPTER.
        2. Is assignable to TypeAdapterFactory then TYPE_ADAPTER_FACTORY.
        3. Is subtype of JsonSerializer then JSON_SERIALIZER.
        4. Is subtype of JsonDeserializer then JSON_DESERIALIZER.
        5. Is subtype of both JsonSerializer, JsonDeserializer then JSON_SERIALIZER_DESERIALIZER.

2. If JsonAdapterType annotation is applied then, typeAdapter member variable is being added for corresponding field with respect to JsonAdapterType.

#### How to Test
 Examples: If JsonAdapterType is
  ## TYPE_ADAPTER
   **Given**    

`@SerializedName("alternate_model1")`
` @JsonAdapter(value = com.vimeo.sample_model.AlternateNameModel$TypeAdapter.class)`
`public com.vimeo.sample_model.AlternateNameModel mRunTimeExample1;`

   Generated TypeAdapter will be
 **Declaration**:

`private final TypeAdapter<AlternateNameModel> mTypeAdapter0;`

 **Initialization**:

`mTypeAdapter0 = new com.vimeo.sample_model.AlternateNameModel$TypeAdapter(gson,new com.vimeo.sample_model.stag.generated.Stag.Factory()).nullSafe();`

 ## TYPE_ADAPTER_FACTORY
   **Given**    

`@SerializedName("alternate_model")`
   `@JsonAdapter(value = com.vimeo.sample_model.stag.generated.Stag.Factory.class)`
   ` public com.vimeo.sample_model.AlternateNameModel mRunTimeExample;`

   Generated TypeAdapter will be
 **Declaration**:

`private final TypeAdapter<AlternateNameModel> mTypeAdapter1;`

 **Initialization**:

`mTypeAdapter1 = new com.vimeo.sample_model.stag.generated.Stag.Factory().create(gson, new com.google.gson.reflect.TypeToken<com.vimeo.sample_model.AlternateNameModel>(){}).nullSafe();`

## JSON_SERIALIZER
   **Given**    

`@SerializedName("user")`
   `@JsonAdapter(value =  TestSerializer.class)`
   ` public User user;`

   Generated TypeAdapter will be
 **Declaration**:

`private final TypeAdapter<User> mTypeAdapter2;`

 **Initialization**:

`mTypeAdapter2 = new com.google.gson.internal.bind.TreeTypeAdapter(new TestSerializer(), null, gson, new com.google.gson.reflect.TypeToken<com.vimeo.sample.model.User>(){}, null).nullSafe();`

## JSON_DESERIALIZER
   **Given**    

`@SerializedName("user")`
   `@JsonAdapter(value =  TestDeserializer.class)`
   ` public User user;`

   Generated TypeAdapter will be
 **Declaration**:

`private final TypeAdapter<User> mTypeAdapter3;`

 **Initialization**:

`mTypeAdapter3 = new com.google.gson.internal.bind.TreeTypeAdapter(null, new TestDeserializer(), gson, new com.google.gson.reflect.TypeToken<com.vimeo.sample.model.User>(){}, null).nullSafe();`

## JSON_SERIALIZER_DESERIALIZER
   **Given**    

`@SerializedName("user")`
   `@JsonAdapter(value =  TestSerializerDeserializer.class)`
   ` public User user;`

   Generated TypeAdapter will be
 **Declaration**:

`private final TypeAdapter<User> mTypeAdapter4;`

 **Initialization**:
`com.vimeo.sample.model.TestSerializerDeserializer userSerializerDeserializer = new TestSerializerDeserializer();`
`mTypeAdapter4 = new com.google.gson.internal.bind.TreeTypeAdapter(userSerializerDeserializer, userSerializerDeserializer, gson, new com.google.gson.reflect.TypeToken<com.vimeo.sample.model.User>(){}, null).nullSafe();`
