### PR TITLE
Final fields should be raised as compile-time errors

### DIFF
--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.testing.compile:compile-testing:0.8'
 
+    // Forcibly add test resources to test classpath: https://code.google.com/p/android/issues/detail?id=64887
+    testRuntime files('build/resources/test')
+
     compile project(':stag-library')
 
     compile 'com.google.code.gson:gson:2.8.0'

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -26,7 +26,6 @@ package com.vimeo.stag.processor;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.JavaFile;
 import com.vimeo.stag.GsonAdapterKey;
-import com.vimeo.stag.KnownTypeAdapters;
 import com.vimeo.stag.UseStag;
 import com.vimeo.stag.processor.generators.AdapterGenerator;
 import com.vimeo.stag.processor.generators.EnumTypeAdapterGenerator;
@@ -39,7 +38,7 @@ import com.vimeo.stag.processor.utils.DebugLog;
 import com.vimeo.stag.processor.utils.ElementUtils;
 import com.vimeo.stag.processor.utils.FileGenUtils;
 import com.vimeo.stag.processor.utils.KnownTypeAdapterFactoriesUtils;
-import com.vimeo.stag.processor.utils.KnownTypeAdapterUtils;
+import com.vimeo.stag.processor.utils.MessagerUtils;
 import com.vimeo.stag.processor.utils.TypeUtils;
 
 import org.jetbrains.annotations.NotNull;
@@ -117,6 +116,7 @@ public final class StagProcessor extends AbstractProcessor {
 
         TypeUtils.initialize(processingEnv.getTypeUtils());
         ElementUtils.initialize(processingEnv.getElementUtils());
+        MessagerUtils.initialize(processingEnv.getMessager());
 
         String stagFactoryGeneratedName = StagGenerator.getGeneratedFactoryClassAndPackage(packageName);
         SupportedTypesModel.getInstance().initialize(stagFactoryGeneratedName);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -28,6 +28,7 @@ import com.vimeo.stag.GsonAdapterKey;
 import com.vimeo.stag.UseStag;
 import com.vimeo.stag.UseStag.FieldOption;
 import com.vimeo.stag.processor.utils.DebugLog;
+import com.vimeo.stag.processor.utils.MessagerUtils;
 import com.vimeo.stag.processor.utils.TypeUtils;
 
 import org.jetbrains.annotations.NotNull;
@@ -121,15 +122,15 @@ public class AnnotatedClass {
     private static void checkModifiers(VariableElement variableElement, Set<Modifier> modifiers) {
         if (!modifiers.contains(Modifier.STATIC)) {
             if (modifiers.contains(Modifier.FINAL)) {
-                throw new RuntimeException("Unable to access field \"" +
+                MessagerUtils.reportError("Unable to access field \"" +
                                            variableElement.getSimpleName().toString() + "\" in class " +
                                            variableElement.getEnclosingElement().asType() +
-                                           ", field must not be final.");
+                                           ", field must not be final.", variableElement);
             } else if (modifiers.contains(Modifier.PRIVATE)) {
-                throw new RuntimeException("Unable to access field \"" +
+                MessagerUtils.reportError("Unable to access field \"" +
                                            variableElement.getSimpleName().toString() + "\" in class " +
                                            variableElement.getEnclosingElement().asType() +
-                                           ", field must not be private.");
+                                           ", field must not be private.", variableElement);
             }
         }
     }
@@ -140,8 +141,7 @@ public class AnnotatedClass {
             if (shouldIncludeField(element, fieldOption)) {
                 final VariableElement variableElement = (VariableElement) element;
                 Set<Modifier> modifiers = variableElement.getModifiers();
-                if (!modifiers.contains(Modifier.FINAL) && !modifiers.contains(Modifier.STATIC) &&
-                    !modifiers.contains(Modifier.TRANSIENT)) {
+                if (!modifiers.contains(Modifier.STATIC) && !modifiers.contains(Modifier.TRANSIENT)) {
                     checkModifiers(variableElement, modifiers);
                     if (!TypeUtils.isAbstract(element)) {
                         SupportedTypesModel.getInstance().checkAndAddExternalAdapter(variableElement);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/MessagerUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/MessagerUtils.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ * <p/>
+ * Copyright (c) 2016 Vimeo
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vimeo.stag.processor.utils;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
+
+public final class MessagerUtils {
+
+    @Nullable
+    private static Messager sMessager;
+
+    private MessagerUtils() {
+        throw new UnsupportedOperationException("This class is not instantiable");
+    }
+
+    public static void initialize(@NotNull Messager messager) {
+        sMessager = messager;
+    }
+
+    @NotNull
+    private static Messager getMessager() {
+        Preconditions.checkNotNull(sMessager);
+        return sMessager;
+    }
+
+    public static void reportError(@NotNull String message, @NotNull Element element) {
+        getMessager().printMessage(Diagnostic.Kind.ERROR, message, element);
+    }
+
+}

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/AbstractAnnotationProcessorTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/AbstractAnnotationProcessorTest.java
@@ -1,0 +1,155 @@
+package com.vimeo.stag.processor;
+
+/*
+ * @(#)AbstractAnnotationProcessorTest.java     5 Jun 2009
+ *
+ * Copyright © 2010 Andrew Phillips.
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.processing.Processor;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import static com.google.common.base.Throwables.propagate;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A base test class for {@link Processor annotation processor} testing that
+ * attempts to compile source test cases that can be found on the classpath.
+ *
+ * @author aphillips
+ * @since 5 Jun 2009
+ */
+abstract class AbstractAnnotationProcessorTest {
+    private static final String SOURCE_FILE_SUFFIX = ".java";
+    private static final JavaCompiler COMPILER = ToolProvider.getSystemJavaCompiler();
+
+    /** @return the processor instances that should be tested */
+    protected abstract Collection<Processor> getProcessors();
+
+    protected List<Diagnostic<? extends JavaFileObject>> compileTestCase(String ... classNames) {
+        DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = COMPILER.getStandardFileManager(diagnosticCollector, null, null);
+            CleanableJavaFileManager cleanableJavaFileManager = new CleanableJavaFileManager(fileManager)) {
+            Collection<File> files = classNamesToFiles(classNames);
+            Iterable<? extends JavaFileObject> javaFileObjects = fileManager.getJavaFileObjectsFromFiles(files);
+            /*
+             * Call the compiler with the "-proc:only" option. The "class names"
+             * option (which could, in principle, be used instead of compilation
+             * units for annotation processing) isn't useful in this case because
+             * that only gives access to the annotation declaration, not the
+             * members.
+             */
+            CompilationTask task = COMPILER.getTask(null, cleanableJavaFileManager, diagnosticCollector,
+                    Collections.singletonList("-proc:only"), null, javaFileObjects);
+            task.setProcessors(getProcessors());
+            task.call();
+
+        } catch (IOException exception) {
+            exception.printStackTrace(System.err);
+        }
+
+        return diagnosticCollector.getDiagnostics();
+    }
+
+    private Collection<File> classNamesToFiles(String ... classNames) {
+        ArrayList<File> files = new ArrayList<>(classNames.length);
+        for (String className : classNames) {
+            files.add(resourceToFile(className + SOURCE_FILE_SUFFIX));
+        }
+        return files;
+    }
+
+    private File resourceToFile(String resourceName) {
+        URL resource = getClass().getResource(resourceName);
+        assert resource.getProtocol().equals("file");
+        try {
+            return new File(resource.toURI());
+        } catch (URISyntaxException e) {
+            throw propagate(e);
+        }
+    }
+
+    protected static void assertCompilationSuccessful(List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+        assert (diagnostics != null);
+
+        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
+            System.err.println("Diagnostic: " + diagnostic);
+            assertFalse("Expected no errors", diagnostic.getKind().equals(Kind.ERROR));
+        }
+    }
+
+    protected static void assertCompilationReturned(Kind expectedDiagnosticKind, long expectedLineNumber,
+        List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+        assert ((expectedDiagnosticKind != null) && (diagnostics != null));
+        boolean expectedDiagnosticFound = false;
+
+        StringBuilder diagnosticsPrintout = new StringBuilder();
+        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
+            diagnosticsPrintout.append(diagnostic.getKind())
+                    .append(" - ")
+                    .append(getSourceIdent(diagnostic))
+                    .append(" - ")
+                    .append(diagnostic.getMessage(Locale.ENGLISH))
+                    .append("\n");
+            if (diagnostic.getKind().equals(expectedDiagnosticKind)
+                && (diagnostic.getLineNumber() == expectedLineNumber)) {
+                expectedDiagnosticFound = true;
+                break;
+            }
+        }
+        if (diagnosticsPrintout.length() == 0) {
+            diagnosticsPrintout.append("No diagnostic result");
+        }
+        assertTrue("Expected a result of kind " + expectedDiagnosticKind
+            + " at line " + expectedLineNumber + "\nFound instead:\n" + diagnosticsPrintout,
+            expectedDiagnosticFound);
+    }
+
+    private static String getSourceIdent(Diagnostic<? extends JavaFileObject> diagnostic) {
+        JavaFileObject source = diagnostic.getSource();
+        if (source == null) {
+            return "unknown";
+        }
+        String name = source.getName();
+        int indexOf = name.lastIndexOf(File.separatorChar);
+        if (indexOf >= 0) {
+            name = name.substring(indexOf + 1);
+        }
+        long lineNumber = diagnostic.getLineNumber();
+        long columnNumber = diagnostic.getColumnNumber();
+        return name + ":" + lineNumber + ":" + columnNumber;
+    }
+}

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/AbstractAnnotationProcessorTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/AbstractAnnotationProcessorTest.java
@@ -49,6 +49,9 @@ import static org.junit.Assert.assertTrue;
  * A base test class for {@link Processor annotation processor} testing that
  * attempts to compile source test cases that can be found on the classpath.
  *
+ * Original source from:
+ *   https://github.com/ngs-doo/dsl-json/blob/master/processor/src/test/java/com/dslplatform/json/AbstractAnnotationProcessorTest.java
+ *
  * @author aphillips
  * @since 5 Jun 2009
  */

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/CleanableJavaFileManager.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/CleanableJavaFileManager.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ * <p/>
+ * Copyright (c) 2016 Vimeo
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.vimeo.stag.processor;
 
 import java.io.IOException;

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/CleanableJavaFileManager.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/CleanableJavaFileManager.java
@@ -1,0 +1,103 @@
+package com.vimeo.stag.processor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+
+/**
+ * {@link JavaFileManager} implementation which tracks created files and allows them to be
+ * systematically deleted.
+ */
+class CleanableJavaFileManager implements JavaFileManager {
+
+    private final LinkedBlockingQueue<FileObject> writtenFiles = new LinkedBlockingQueue<>();
+    private final JavaFileManager delegate;
+
+    CleanableJavaFileManager(JavaFileManager delegate) {
+        this.delegate = delegate;
+    }
+
+    void purge() throws IOException {
+        ArrayList<FileObject> toDelete = new ArrayList<>();
+        writtenFiles.drainTo(toDelete);
+        for (FileObject file : toDelete) {
+            file.delete();
+        }
+    }
+
+    @Override
+    public ClassLoader getClassLoader(Location location) {
+        return delegate.getClassLoader(location);
+    }
+
+    @Override
+    public Iterable<JavaFileObject> list(Location location, String s, Set<JavaFileObject.Kind> set, boolean b) throws IOException {
+        return delegate.list(location, s, set, b);
+    }
+
+    @Override
+    public String inferBinaryName(Location location, JavaFileObject javaFileObject) {
+        return delegate.inferBinaryName(location, javaFileObject);
+    }
+
+    @Override
+    public boolean isSameFile(FileObject fileObject, FileObject fileObject1) {
+        return delegate.isSameFile(fileObject, fileObject1);
+    }
+
+    @Override
+    public boolean handleOption(String s, Iterator<String> iterator) {
+        return delegate.handleOption(s, iterator);
+    }
+
+    @Override
+    public boolean hasLocation(Location location) {
+        return delegate.hasLocation(location);
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForInput(Location location, String s, JavaFileObject.Kind kind) throws IOException {
+        return delegate.getJavaFileForInput(location, s, kind);
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForOutput(Location location, String s, JavaFileObject.Kind kind, FileObject fileObject) throws IOException {
+        JavaFileObject javaFileForOutput = delegate.getJavaFileForOutput(location, s, kind, fileObject);
+        writtenFiles.add(javaFileForOutput);
+        return javaFileForOutput;
+    }
+
+    @Override
+    public FileObject getFileForInput(Location location, String s, String s1) throws IOException {
+        return delegate.getFileForInput(location, s, s1);
+    }
+
+    @Override
+    public FileObject getFileForOutput(Location location, String s, String s1, FileObject fileObject) throws IOException {
+        FileObject fileForOutput = delegate.getFileForOutput(location, s, s1, fileObject);
+        writtenFiles.add(fileForOutput);
+        return fileForOutput;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+        purge();
+    }
+
+    @Override
+    public int isSupportedOption(String s) {
+        return delegate.isSupportedOption(s);
+    }
+}

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ * <p/>
+ * Copyright (c) 2016 Vimeo
+ * <p/>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p/>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p/>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.vimeo.stag.processor;
 
 import org.junit.Test;
@@ -10,11 +33,9 @@ import javax.tools.Diagnostic;
 
 public class StagProcessorFunctionalTest extends AbstractAnnotationProcessorTest {
 
-    private StagProcessor processor;
-
     @Override
     protected Collection<javax.annotation.processing.Processor> getProcessors() {
-        processor = new StagProcessor();
+        StagProcessor processor = new StagProcessor();
         return Collections.<Processor>singletonList(processor);
     }
 

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.java
@@ -1,0 +1,39 @@
+package com.vimeo.stag.processor;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.processing.Processor;
+import javax.tools.Diagnostic;
+
+public class StagProcessorFunctionalTest extends AbstractAnnotationProcessorTest {
+
+    private StagProcessor processor;
+
+    @Override
+    protected Collection<javax.annotation.processing.Processor> getProcessors() {
+        processor = new StagProcessor();
+        return Collections.<Processor>singletonList(processor);
+    }
+
+    /**
+     * Ensure that final fields result in compile-time errors to prevent silent omission of fields
+     * from generated type adapters.
+     */
+    @Test
+    public void finalFieldsInAnnotatedClassReportsAsAnError() throws Exception {
+        assertCompilationReturned(Diagnostic.Kind.ERROR, 8, compileTestCase("bad/FinalFields"));
+    }
+
+    /**
+     * Ensure that private fields result in compile-time errors to prevent silent omission of fields
+     * from generated type adapters.
+     */
+    @Test
+    public void privateFieldsInAnnotatedClassReportsAsAnError() throws Exception {
+        assertCompilationReturned(Diagnostic.Kind.ERROR, 8, compileTestCase("bad/PrivateFields"));
+    }
+
+}

--- a/stag-library-compiler/src/test/resources/com/vimeo/stag/processor/bad/FinalFields.java
+++ b/stag-library-compiler/src/test/resources/com/vimeo/stag/processor/bad/FinalFields.java
@@ -1,0 +1,20 @@
+package com.vimeo.stag.processor;
+
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class FinalFields {
+
+    final String finalString;
+
+    public FinalFields()
+    {
+        finalString = null;
+    }
+
+    public FinalFields(String finalString)
+    {
+        this.finalString = finalString;
+    }
+
+}

--- a/stag-library-compiler/src/test/resources/com/vimeo/stag/processor/bad/PrivateFields.java
+++ b/stag-library-compiler/src/test/resources/com/vimeo/stag/processor/bad/PrivateFields.java
@@ -1,0 +1,20 @@
+package com.vimeo.stag.processor;
+
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class PrivateFields {
+
+    private String privateString;
+
+    public PrivateFields()
+    {
+        privateString = null;
+    }
+
+    public PrivateFields(String privateString)
+    {
+        this.privateString = privateString;
+    }
+
+}


### PR DESCRIPTION
#### Ticket Summary

Previous behavior was to silently omit the final fields from the set of
fields supported by the generated type adapter.

Also adds functional testing capabilities primarily to test compilation
failure scenarios.

#### Implementation Summary

Implementation is primarily in the creation of compilation failure report testing.

#### How to Test

Attempt to use final or private fields in a model class and observe the beautiful compile-time
error. 😄   Note the transition from throwing exceptions upon failure to using the actual annotation processor's Messager instance which points the user at the location in the code (i.e., linked in the IDE etc.).