### PR TITLE
Fix for enums not being able to have private or final fields.

### DIFF
--- a/sample-model/src/main/java/com/vimeo/sample_model/EnumWithFieldsModel.java
+++ b/sample-model/src/main/java/com/vimeo/sample_model/EnumWithFieldsModel.java
@@ -1,0 +1,23 @@
+package com.vimeo.sample_model;
+
+import com.vimeo.stag.UseStag;
+
+/**
+ * An enum with a field.
+ */
+@UseStag
+public enum EnumWithFieldsModel {
+    ENUM_1("test_1"),
+    ENUM_2("test_2");
+
+    private final String field;
+
+    EnumWithFieldsModel(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+}

--- a/sample-model/src/test/java/com/vimeo/sample_model/EnumWithFieldsModelTest.java
+++ b/sample-model/src/test/java/com/vimeo/sample_model/EnumWithFieldsModelTest.java
@@ -1,0 +1,15 @@
+package com.vimeo.sample_model;
+
+import org.junit.Test;
+
+/**
+ * Created by anthonycr on 4/9/17.
+ */
+public class EnumWithFieldsModelTest {
+
+    @Test
+    public void typeAdapterWasGenerated() throws Exception {
+        Utils.verifyTypeAdapterGeneration(EnumWithFieldsModel.class);
+    }
+
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -90,8 +90,10 @@ public class AnnotatedClass {
             }
         }
 
-        for (Element enclosedElement : element.getEnclosedElements()) {
-            addToSupportedTypes(enclosedElement, fieldOption, variableNames);
+        if (!TypeUtils.isEnum(element)) {
+            for (Element enclosedElement : element.getEnclosedElements()) {
+                addToSupportedTypes(enclosedElement, fieldOption, variableNames);
+            }
         }
 
     }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -285,6 +285,20 @@ public final class TypeUtils {
     }
 
     /**
+     * Determines whether the element is of the enum type or not.
+     *
+     * @param element the element to check.
+     * @return true if the element inherits from an enum, false otherwise.
+     */
+    public static boolean isEnum(@Nullable Element element) {
+        TypeElement typeElement = (TypeElement) element;
+        TypeMirror typeMirror = typeElement != null ? typeElement.getSuperclass() : null;
+        String className = typeMirror != null ? getClassNameFromTypeMirror(typeMirror) : null;
+
+        return Enum.class.getName().equals(className);
+    }
+
+    /**
      * Retrieves a Map of the inherited concrete member variables of an Element. This takes all the
      * member variables that were inherited from the generic parent class and evaluates what their concrete
      * type will be based on the concrete inherited type. For instance, take the following code example:

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
@@ -24,6 +24,7 @@
 package com.vimeo.stag.processor;
 
 import com.vimeo.stag.processor.dummy.DummyAbstractClass;
+import com.vimeo.stag.processor.dummy.DummyClassWithConstructor;
 import com.vimeo.stag.processor.dummy.DummyConcreteClass;
 import com.vimeo.stag.processor.dummy.DummyEnumClass;
 import com.vimeo.stag.processor.dummy.DummyGenericClass;
@@ -159,6 +160,20 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
                                                    .toString()));
             }
         }
+    }
+
+    @Test
+    public void isEnum_isCorrect() throws Exception {
+        assertTrue(TypeUtils.isEnum(Utils.getElementFromClass(DummyEnumClass.class)));
+
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyAbstractClass.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyClassWithConstructor.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyConcreteClass.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyGenericClass.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyInheritedClass.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyMapClass.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(Object.class)));
+        assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(String.class)));
     }
 
     @Test


### PR DESCRIPTION
#### Ticket
https://github.com/vimeo/stag-java/issues/81

#### Ticket Summary
Enums could not have private or final fields as of the 2.1.0 release due to a bug in the modifier checking.

#### Implementation Summary
The solution was to ignore fields for enum types. A method was added to `TypeUtils` to determine whether an object was an enum type or not, and a test was added to verify it. A model has been added to the `sample-model` module to test this scenario.

#### How to Test
Run the tests.
