### PR TITLE
Adding info to readme about artifact versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Stag improves Gson performance by automatically generating reflection-less TypeA
 | master | [![Build Status](https://travis-ci.org/vimeo/stag-java.svg?branch=master)](https://travis-ci.org/vimeo/stag-java) |
 | dev    | [![Build Status](https://travis-ci.org/vimeo/stag-java.svg?branch=dev)](https://travis-ci.org/vimeo/stag-java) |
 
+| Artifact | Latest Version |
+|----------|----------------|
+| stag-library | [![Download](https://api.bintray.com/packages/vimeo/maven/stag-library/images/download.svg)](https://bintray.com/vimeo/maven/stag-library/_latestVersion) |
+| stag-library-compiler | [![Download](https://api.bintray.com/packages/vimeo/maven/stag-library-compiler/images/download.svg)](https://bintray.com/vimeo/maven/stag-library-compiler/_latestVersion) |
 
 ## Why Build Stag?
 


### PR DESCRIPTION
#### Summary
It's helpful to be able to see what the latest version of a library is and where it is available. I've added the bintray badge for each artifact to the readme to make it easier to see what the latest available artifact is.