### PR TITLE
added fix for TypeAdpater generation having Object fieldType

### DIFF
--- a/sample/src/main/java/com/vimeo/sample/model/ObjectExample.java
+++ b/sample/src/main/java/com/vimeo/sample/model/ObjectExample.java
@@ -1,0 +1,13 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.stag.UseStag;
+
+/**
+ * Example where Object is one of the member variables
+ *
+ */
+@UseStag
+public class ObjectExample {
+
+    Object objectExample;
+}

--- a/sample/src/test/java/com/vimeo/sample/model/ObjectExampleTest.java
+++ b/sample/src/test/java/com/vimeo/sample/model/ObjectExampleTest.java
@@ -1,0 +1,16 @@
+package com.vimeo.sample.model;
+
+import com.vimeo.sample.Utils;
+
+import org.junit.Test;
+
+/**
+ * Created by anshul.garg on 12/04/17.
+ */
+public class ObjectExampleTest {
+    @Test
+    public void typeAdapterWasGenerated() throws Exception {
+        Utils.verifyTypeAdapterGeneration(ObjectExample.class);
+    }
+
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -529,6 +529,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                  * If the fieldType is Object, use ObjectTypeAdapter
                  */
                 sGsonVariableUsed = true;
+                sStagFactoryUsed = true;
                 String adapterCode = "new " + TypeUtils.className(ObjectTypeAdapter.class) + "(mGson)";
                 String getterName = stagGenerator.addFieldForKnownType(fieldType,
                                                                        adapterCode.replaceAll("mStagFactory.",


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[TICKET_NUMBER](https://vimean.atlassian.net/browse/TICKET_NUMBER)

#### Ticket Summary
Fix for issue reported [https://github.com/vimeo/stag-java/issues/87](url)
In case of object fieldType, typeadapter uses stagFactory but does not have stagFactory as a member variable.

#### Implementation Summary
In TypeAdapterGenerator file added sStagFactoryUsed = true in case of object field type.

#### How to Test
Added a test case example also. ObjectExample class.
