### PR TITLE
[WIP] Removing android-apt plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,8 @@ The Stag library solves this problem. It leverages annotations to automatically 
 
 #### 1. Add the Stag dependencies
 
-from jCenter
-```groovy
-dependencies {
-    compile 'com.vimeo.stag:stag-library:2.1.2'
-    apt 'com.vimeo.stag:stag-library-compiler:2.1.2'
-}
-```
+### Java Gradle
 
-or as a submodule
-```groovy
-dependencies {
-    compile project(':stag-library')
-    apt project(':stag-library-compiler')
-}
-```
-
-#### 2. Add the Annotation Processor Plugin
-
-In a Java project (see below for Android), apply the 'apt' plugin in your module-level `build.gradle`:
 ```groovy
 buildscript {
     repositories {
@@ -58,39 +41,54 @@ buildscript {
 }
 
 apply plugin: 'net.ltgt.apt'
-```
 
-In an Android project, apply the 'android-apt' plugin in your module-level `build.gradle`:
-```groovy
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    }
+dependencies {
+    compile 'com.vimeo.stag:stag-library:2.1.2'
+    apt 'com.vimeo.stag:stag-library-compiler:2.1.2'
 }
 
-apply plugin: 'com.neenbedankt.android-apt'
+// Optional annotation processor arguments (see below)
+apt {
+    arguments {
+        stagGeneratedPackageName "com.vimeo.sample.stag.generated"
+        stagDebug true
+    }
+}
 ```
 
-#### 3. Provide optional compiler arguments to Stag
+### Android Gradle
+
+from jCenter
+```groovy
+dependencies {
+    compile 'com.vimeo.stag:stag-library:2.1.2'
+    annotationProcessor 'com.vimeo.stag:stag-library-compiler:2.1.2'
+}
+
+android {
+    ...
+    defaultConfig {
+        ...
+        // Optional annotation processor arguments (see below)
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                    stagGeneratedPackageName: 'com.vimeo.sample.stag.generated',
+                    stagDebug               : 'true'
+                ]
+            }
+        }
+    }
+}
+```
+
+#### 2. Provide optional compiler arguments to Stag
  - `stagGeneratedPackageName`: Pass package name as an argument for the generated files. By default, the files will be in generated
  in `com.vimeo.sample.stag.generated` package. But, you can specify your own package for the generated files
  by passing it as an argument to the apt compiler.
  - `stagDebug`: Turn on debugging in Stag. This will cause Stag to spit out a lot of output into the gradle console.
  This can aid you in figuring out what class is giving you trouble, if the exception gradle prints out
  isn't sufficient.
-
-```groovy
-apt {
-    arguments {
-        stagGeneratedPackageName "com.vimeo.sample.stag.generated"
-
-        stagDebug true
-    }
-}
-```
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The Stag library solves this problem. It leverages annotations to automatically 
 
 #### 1. Add the Stag dependencies
 
+All jar dependencies are available on jcenter.
+
 ### Java Gradle
 
 ```groovy
@@ -58,7 +60,6 @@ apt {
 
 ### Android Gradle
 
-from jCenter
 ```groovy
 dependencies {
     compile 'com.vimeo.stag:stag-library:2.1.2'
@@ -153,7 +154,7 @@ public class Herd {
 
     @NonNull                     // add NonNull annotation to throw an exception if the field is null
     @SerializedName("data_list")
-    ArrayList<Deer> data;        // data_list = json value with key "data_list"
+    ArrayList<Deer> data;        // data = json value with key "data_list"
     
     List<Deer> data_list_copy;   // data_list_copy = json value with key "data_list_copy"
     

--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -4,12 +4,7 @@ buildscript {
     repositories {
         jcenter()
     }
-    dependencies {
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    }
 }
-
-apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     // Please update the ".travis.yml" file "android.components" section
@@ -21,6 +16,15 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                        stagGeneratedPackageName: 'com.vimeo.sample_model.stag.generated',
+                        stagDebug               : 'true'
+                ]
+            }
+        }
     }
     buildTypes {
         release {
@@ -37,15 +41,8 @@ dependencies {
     compile 'com.android.support:support-annotations:25.3.1'
 
     compile project(':stag-library')
-    apt project(':stag-library-compiler')
+    annotationProcessor project(':stag-library-compiler')
     compile 'com.google.code.gson:gson:2.8.0'
-}
-
-apt {
-    arguments {
-        stagGeneratedPackageName "com.vimeo.sample_model.stag.generated"
-        stagDebug true
-    }
 }
 
 gradle.projectsEvaluated {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,12 +5,7 @@ buildscript {
     repositories {
         jcenter()
     }
-    dependencies {
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-    }
 }
-
-apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     // Please update the ".travis.yml" file "android.components" section
@@ -23,6 +18,15 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                        stagGeneratedPackageName: 'com.vimeo.sample.stag.generated',
+                        stagDebug               : 'true'
+                ]
+            }
+        }
     }
     buildTypes {
         release {
@@ -42,15 +46,8 @@ dependencies {
     compile project(':stag-library')
     compile project(':sample-model')
     compile project(':sample-java-model')
-    apt project(':stag-library-compiler')
+    annotationProcessor project(':stag-library-compiler')
     compile 'com.google.code.gson:gson:2.8.0'
-}
-
-apt {
-    arguments {
-        stagGeneratedPackageName "com.vimeo.sample.stag.generated"
-        stagDebug true
-    }
 }
 
 gradle.projectsEvaluated {


### PR DESCRIPTION
#### Summary
Gradle has supported annotation processing natively since gradle plugin 2.2, so the `android-apt` plugin is not necessary. I think it would be better if our samples and readme relied on this rather than an additional plugin.

I've removed the `android-apt` plugin from the `:sample` and `:sample-model` modules.
