### PR TITLE
Support the latest version of Java

### DIFF
--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -75,7 +75,8 @@ public final class StagProcessor extends AbstractProcessor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_7;
+        // Always try to support the latest Java version
+        return SourceVersion.latestSupported();
     }
 
     private static boolean getDebugBoolean(@NotNull ProcessingEnvironment processingEnvironment) {


### PR DESCRIPTION
#### Ticket
https://github.com/vimeo/stag-java/issues/100

#### Ticket Summary
The stag compiler doesn't support usage in Java 8 or above.

#### Implementation Summary
The simplest fix was to increase the supported source version that `StagProcessor` returned. Instead of returning `RELEASE_7`, we will just get the latest version and support that.

#### How to Test
Increase the sourceCompatibility and targetCompatibility of `sample-java-model` to 1.8 and observe that it no longer fails with a warning.
