### PR TITLE
CI-487: publish stag artifacts and doc to MavenCentral

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 - rvm install 2.2
 - rvm use 2.2
 - bundle install
-- FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane test
+- FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane shipit
 - ./gradlew jacocoTestReport --stacktrace
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.3.1 *(2017-06-27)*
+----------------------------
+- Stag is now being deployed to Maven Central.
+
 Version 2.3.0 *(2017-06-22)*
 ----------------------------
 - Stag now throws an exception if you try to reuse a `Stag.Factory` instance between multiple gson instances.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ buildscript {
 apply plugin: 'net.ltgt.apt'
 
 dependencies {
-    compile 'com.vimeo.stag:stag-library:2.3.0'
-    apt 'com.vimeo.stag:stag-library-compiler:2.3.0'
+    compile 'com.vimeo.stag:stag-library:2.3.1'
+    apt 'com.vimeo.stag:stag-library-compiler:2.3.1'
 }
 
 // Optional annotation processor arguments (see below)
@@ -67,8 +67,8 @@ apt {
 
 ```groovy
 dependencies {
-    compile 'com.vimeo.stag:stag-library:2.3.0'
-    annotationProcessor 'com.vimeo.stag:stag-library-compiler:2.3.0'
+    compile 'com.vimeo.stag:stag-library:2.3.1'
+    annotationProcessor 'com.vimeo.stag:stag-library-compiler:2.3.1'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -38,5 +38,5 @@ allprojects {
 
 subprojects {
     group = 'com.vimeo.stag'
-    version = '2.3.0'
+    version = '2.3.1'
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,12 +28,42 @@ platform :android do
     end
   end
 
+  desc "main entrypoint for CI"
+  lane :shipit do
+    if is_ci
+      # If the build was triggered by a Pull Request
+      if ENV['TRAVIS_PULL_REQUEST'] && ENV['TRAVIS_PULL_REQUEST'] != 'false'
+        test
+      else
+        # This build was triggered by a branch update
+        branch = git_branch
+        # If the branch is master, this means new updates were merged into master
+        # Then publish the artifacts to bintray
+        if branch == 'master'
+          publish_artifacts(
+            snapshot: false
+          )
+
+          # TODO: publish Snapshots with snapshot = true
+        end
+      end
+    end
+  end
+
+  desc "publish artifacts to bintray. Use the 'snapshot' option (boolean) to publish a Snapshot instead of a release (not implemented yet)"
+  lane :publish_artifacts do |options|
+    # Upload to bintray
+    gradle(
+      task: "stag-library:bintrayUpload stag-library-compiler:bintrayUpload",
+      properties: {
+        "snapshot" => options[:snapshot]
+      }
+    )
+  end
+
   desc "test"
   lane :test do
     
-  # gotta do some setup before running gradle
-  sh 'touch ../local.properties'
-
   # run the tests, but dont puke everywhere until the report is printed.
   junit_report_path_array = [
     "stag-library/build/test-results/test/*.xml",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,11 +1,45 @@
 fastlane documentation
 ================
 # Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
 ```
-sudo gem install fastlane
+xcode-select --install
 ```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+
 # Available Actions
 ## Android
+### android shipit
+```
+fastlane android shipit
+```
+main entrypoint for CI
+### android publish_artifacts
+```
+fastlane android publish_artifacts
+```
+publish artifacts to bintray. Use the 'snapshot' option (boolean) to publish a Snapshot instead of a release (not implemented yet)
 ### android test
 ```
 fastlane android test
@@ -15,5 +49,5 @@ test
 ----
 
 This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
-More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -47,6 +47,8 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+tasks.withType(Javadoc).all { enabled = true }
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
@@ -56,35 +58,67 @@ artifacts {
     archives sourcesJar, javadocJar
 }
 
+// Create the pom configuration
+// All the fields below are required by Maven Central
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT License"
+            url "http://www.opensource.org/licenses/mit-license.php"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "vimeo"
+            name "Vimeo Mobile"
+            email "mobileops@vimeo.com"
+            organisation "Vimeo"
+            organisationUrl "https://github.com/vimeo"
+        }
+    }
+    
+    scm {
+        connection "scm:git:git://github.com/vimeo/stag-java.git"
+        developerConnection "scm:git:ssh://github.com:vimeo/stag-java.git"
+        url "https://github.com/vimeo/stag-java"
+    }
+}
+
+// Create the publication with the pom configuration:
 // Requires apply plugin: maven-publish
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            // We don't have any complex artifacts, so let's just
-            // reference the fact that we rely on plugin java
+        MyPublication(MavenPublication) {
             from components.java
+            artifact sourcesJar
+            artifact javadocJar
             groupId project.group
             artifactId 'stag-library-compiler'
             version project.version
-
-            artifact sourcesJar
-            artifact javadocJar
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Stag improves Gson performance by automatically generating reflection-less TypeAdapters for your model objects.')
+                root.appendNode('name', 'stag-library-compiler')
+                root.appendNode('url', 'https://github.com/vimeo/stag-java')
+                root.children().last() + pomConfig
+            }
         }
     }
 }
 
-// Only execute the bintray task if this is the actual stag-library-compilers project (not an include)
+// Only execute the bintray task if this is the actual networking project (not an include)
 allprojects {
     afterEvaluate { project ->
         def bintrayProject = project.plugins.hasPlugin('com.jfrog.bintray')
         if (bintrayProject) {
             bintray {
-                Properties properties = new Properties()
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                user = properties.getProperty('bintray.user')
-                key = properties.getProperty('bintray.apikey')
-                publications = ['mavenJava']
+                user = System.getenv('BINTRAY_USER')
+                // api key
+                key = System.getenv('BINTRAY_API_KEY')
+                publications = ['MyPublication']
                 dryRun = false // Whether to run this as dry-run, without deploying
+                override = false
                 pkg {
                     repo = 'maven'
                     name = 'stag-library-compiler'
@@ -98,6 +132,16 @@ allprojects {
                     version {
                         name = project.version
                         vcsTag = project.version
+                        gpg {
+                            sign = true
+                            passphrase = System.getenv('BINTRAY_GPG_PASSWORD')
+                        }
+                        mavenCentralSync {
+                            sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
+                            user = System.getenv('SONATYPE_TOKEN_USER') //OSS user token
+                            password = System.getenv('SONATYPE_TOKEN_PASSWORD') //OSS user password
+                            close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+                        }
                     }
                 }
             }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -301,22 +301,20 @@ public final class TypeUtils {
      * Retrieves a Map of the inherited concrete member variables of an Element. This takes all the
      * member variables that were inherited from the generic parent class and evaluates what their concrete
      * type will be based on the concrete inherited type. For instance, take the following code example:
-     * <pre>
-     * {@code
-     * Factory<T> {
+     * <pre><code>
+     * {@literal Factory<T>} {
      *
-     *  @literal @UseStag
+     *  {@literal @UseStag}
      *   public T data;
      *
      * }
      *
-     * VideoFactory extends Factory<Video> {
+     * VideoFactory extends {@literal Factory<Video>}{
      *
      *   // other variables in here
      *
      * }
-     * }
-     * </pre>
+     * </code></pre>
      * In this example, VideoFactory has a public member variable T that is of type Video.
      * Since the Factory class has the UseStag annotation, we cannot just generate
      * parsing code for the Factory class, since it is generic and we need concrete types.

--- a/stag-library/build.gradle
+++ b/stag-library/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+tasks.withType(Javadoc).all { enabled = true }
+
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
@@ -42,35 +44,67 @@ artifacts {
     archives sourcesJar, javadocJar
 }
 
+// Create the pom configuration
+// All the fields below are required by Maven Central
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT License"
+            url "http://www.opensource.org/licenses/mit-license.php"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "vimeo"
+            name "Vimeo Mobile"
+            email "mobileops@vimeo.com"
+            organisation "Vimeo"
+            organisationUrl "https://github.com/vimeo"
+        }
+    }
+    
+    scm {
+        connection "scm:git:git://github.com/vimeo/stag-java.git"
+        developerConnection "scm:git:ssh://github.com:vimeo/stag-java.git"
+        url "https://github.com/vimeo/stag-java"
+    }
+}
+
+// Create the publication with the pom configuration:
 // Requires apply plugin: maven-publish
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            // We don't have any complex artifacts, so let's just
-            // reference the fact that we rely on the java plugin
+        MyPublication(MavenPublication) {
             from components.java
+            artifact sourcesJar
+            artifact javadocJar
             groupId project.group
             artifactId 'stag-library'
             version project.version
-
-            artifact sourcesJar
-            artifact javadocJar
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Stag improves Gson performance by automatically generating reflection-less TypeAdapters for your model objects.')
+                root.appendNode('name', 'stag-library')
+                root.appendNode('url', 'https://github.com/vimeo/stag-java')
+                root.children().last() + pomConfig
+            }
         }
     }
 }
 
-// Only execute the bintray task if this is the actual stag-library project (not an include)
+// Only execute the bintray task if this is the actual networking project (not an include)
 allprojects {
     afterEvaluate { project ->
         def bintrayProject = project.plugins.hasPlugin('com.jfrog.bintray')
         if (bintrayProject) {
             bintray {
-                Properties properties = new Properties()
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                user = properties.getProperty('bintray.user')
-                key = properties.getProperty('bintray.apikey')
-                publications = ['mavenJava']
+                user = System.getenv('BINTRAY_USER')
+                // api key
+                key = System.getenv('BINTRAY_API_KEY')
+                publications = ['MyPublication']
                 dryRun = false // Whether to run this as dry-run, without deploying
+                override = false
                 pkg {
                     repo = 'maven'
                     name = 'stag-library'
@@ -84,6 +118,16 @@ allprojects {
                     version {
                         name = project.version
                         vcsTag = project.version
+                        gpg {
+                            sign = true
+                            passphrase = System.getenv('BINTRAY_GPG_PASSWORD')
+                        }
+                        mavenCentralSync {
+                            sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
+                            user = System.getenv('SONATYPE_TOKEN_USER') //OSS user token
+                            password = System.getenv('SONATYPE_TOKEN_PASSWORD') //OSS user password
+                            close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+                        }
                     }
                 }
             }

--- a/stag-library/src/main/java/com/vimeo/stag/UseStag.java
+++ b/stag-library/src/main/java/com/vimeo/stag/UseStag.java
@@ -33,10 +33,10 @@ import java.lang.annotation.Target;
 /**
  * Use this annotation to tell Stag that all the member variables
  * of the class should be processed.
- * <p/>
+ * <p>
  * If the class is annotated, Stag will generate a TypeAdapter for
  * that class. Stag does not generate TypeAdapters for abstract classes.
- * <p/>
+ * </p>
  */
 @Target({ElementType.TYPE})
 public @interface UseStag {


### PR DESCRIPTION
#### Ticket
**Required for Vimeans only**
[CI-487](https://vimean.atlassian.net/browse/CI-487)

#### Ticket Summary
publish stag artifacts and doc to MavenCentral

#### Implementation Summary
Based on the work done for vimeo-networking:

- Fixed Javadoc errors
- Updated Fastlane config
- Updated build.gradle to add the proper pom.xml to stag-library and stag-library-compiler to conform to Metadata needed by Maven central and bintray.
- Bumped version to 2.3.1