### PR TITLE
Fix bug where private parameterized fields could not be found

### DIFF
--- a/sample-model/build.gradle
+++ b/sample-model/build.gradle
@@ -21,8 +21,9 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                        stagGeneratedPackageName: 'com.vimeo.sample_model.stag.generated',
-                        stagDebug               : 'true'
+                        stagGeneratedPackageName   : 'com.vimeo.sample_model.stag.generated',
+                        stagDebug                  : 'true',
+                        stagAssumeHungarianNotation: 'true'
                 ]
             }
         }

--- a/sample-model/src/main/java/com/vimeo/sample_model/ExternalModelGeneric1.java
+++ b/sample-model/src/main/java/com/vimeo/sample_model/ExternalModelGeneric1.java
@@ -9,11 +9,35 @@ import com.vimeo.stag.UseStag;
 public class ExternalModelGeneric1<T> {
 
     @SerializedName("field2")
-    public String mField2;
+    private String mField2;
 
     @SerializedName("genericField")
-    public T mGenericField;
+    private T mGenericField;
 
     @SerializedName("unknownType")
-    public ValueCallback<T> mUnknownType;
+    private ValueCallback<T> mUnknownType;
+
+    public String getField2() {
+        return mField2;
+    }
+
+    public void setField2(String field2) {
+        mField2 = field2;
+    }
+
+    public T getGenericField() {
+        return mGenericField;
+    }
+
+    public void setGenericField(T genericField) {
+        mGenericField = genericField;
+    }
+
+    public ValueCallback<T> getUnknownType() {
+        return mUnknownType;
+    }
+
+    public void setUnknownType(ValueCallback<T> unknownType) {
+        mUnknownType = unknownType;
+    }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -108,8 +108,8 @@ public class AnnotatedClass {
             AnnotatedClass genericInheritedType = mSupportedTypesModel.addToKnownInheritedType(inheritedType, fieldOption);
 
             LinkedHashMap<FieldAccessor, TypeMirror> inheritedMemberVariables = TypeUtils.getConcreteMembers(inheritedType,
-                genericInheritedType.getElement(),
-                genericInheritedType.getMemberVariables());
+                                                                                                             genericInheritedType.getElement(),
+                                                                                                             genericInheritedType.getMemberVariables());
 
             for (Map.Entry<FieldAccessor, TypeMirror> entry : inheritedMemberVariables.entrySet()) {
                 addMemberVariable(entry.getKey(), entry.getValue(), variableNames);
@@ -132,7 +132,7 @@ public class AnnotatedClass {
         if (null != previousElement) {
             mMemberVariables.remove(previousElement);
             MessagerUtils.logInfo("Ignoring inherited Member variable with the same variable name in class" +
-                element.toString() + ", with variable name " + previousElement.asType().toString());
+                                  element.toString() + ", with variable name " + previousElement.asType().toString());
         }
         mMemberVariables.put(element, typeMirror);
     }
@@ -142,9 +142,9 @@ public class AnnotatedClass {
 
         if (modifiers.contains(Modifier.FINAL)) {
             MessagerUtils.reportError("Unable to access field \"" +
-                variableElement.getSimpleName().toString() + "\" in class " +
-                variableElement.getEnclosingElement().asType() +
-                ", field must not be final.", variableElement);
+                                      variableElement.getSimpleName().toString() + "\" in class " +
+                                      variableElement.getEnclosingElement().asType() +
+                                      ", field must not be final.", variableElement);
         }
 
         return modifiers.contains(Modifier.FINAL) || modifiers.contains(Modifier.PRIVATE);
@@ -165,7 +165,7 @@ public class AnnotatedClass {
                     try {
                         addMemberVariable(new MethodFieldAccessor(element, mNamingNotation), element.asType(), variableNames);
                     } catch (UnsupportedOperationException exception) {
-                        MessagerUtils.reportError("Unable to find getter/setter for private/final field", element);
+                        MessagerUtils.reportError(exception.getMessage(), element);
                     }
                 } else {
                     addMemberVariable(new DirectFieldAccessor(element), element.asType(), variableNames);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -124,7 +124,7 @@ public final class ClassInfo {
         ClassInfo classInfo = (ClassInfo) o;
 
         return mClassName.equals(classInfo.mClassName) && mPackageName.equals(classInfo.mPackageName) &&
-               mTypeName.equals(classInfo.mTypeName) && mType.equals(classInfo.mType);
+               mTypeName.equals(classInfo.mTypeName) && TypeUtils.areEqual(mType, classInfo.mType);
 
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/accessor/MethodFieldAccessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/accessor/MethodFieldAccessor.java
@@ -1,6 +1,7 @@
 package com.vimeo.stag.processor.generators.model.accessor;
 
 import com.vimeo.stag.processor.utils.MessagerUtils;
+import com.vimeo.stag.processor.utils.TypeUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -59,8 +60,6 @@ public class MethodFieldAccessor extends FieldAccessor {
         List<ExecutableElement> methodElements = new ArrayList<>();
         List<? extends Element> otherElements = variableElement.getEnclosingElement().getEnclosedElements();
 
-        MessagerUtils.logInfo("Looking for setter and getter");
-
         for (Element element : otherElements) {
             if (element.getKind() == ElementKind.METHOD && element instanceof ExecutableElement) {
                 methodElements.add((ExecutableElement) element);
@@ -73,7 +72,7 @@ public class MethodFieldAccessor extends FieldAccessor {
     @NotNull
     private static String findSetterMethodName(@NotNull VariableElement variableElement,
                                                @NotNull Notation namingNotation) throws UnsupportedOperationException {
-        MessagerUtils.logInfo("Looking for setter and getter");
+        MessagerUtils.logInfo("Looking for setter");
 
         for (ExecutableElement method : getSiblingMethods(variableElement)) {
 
@@ -81,7 +80,7 @@ public class MethodFieldAccessor extends FieldAccessor {
 
             if (method.getReturnType().getKind() == TypeKind.VOID &&
                 parameters.size() == 1 &&
-                parameters.get(0).asType().equals(variableElement.asType()) &&
+                TypeUtils.areEqual(parameters.get(0).asType(), variableElement.asType()) &&
                 method.getSimpleName().toString().equals("set" + getVariableNameAsMethodName(variableElement, namingNotation))) {
                 MessagerUtils.logInfo("Found setter");
 
@@ -96,11 +95,11 @@ public class MethodFieldAccessor extends FieldAccessor {
     @NotNull
     private static String findGetterMethodName(@NotNull VariableElement variableElement,
                                                @NotNull Notation namingNotation) throws UnsupportedOperationException {
-        MessagerUtils.logInfo("Looking for setter and getter");
+        MessagerUtils.logInfo("Looking for getter");
 
         for (ExecutableElement method : getSiblingMethods(variableElement)) {
 
-            if (method.getReturnType().equals(variableElement.asType()) &&
+            if (TypeUtils.areEqual(method.getReturnType(), variableElement.asType()) &&
                 method.getParameters().isEmpty() &&
                 method.getSimpleName().toString().equals("get" + getVariableNameAsMethodName(variableElement, namingNotation))) {
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -172,7 +172,7 @@ public final class TypeUtils {
      * @param typeMirror2 the second type to compare.
      * @return true if they are equal, false otherwise.
      */
-    public static boolean areEqual(@Nullable TypeMirror typeMirror1, @Nullable TypeMirror typeMirror2) {
+    public static boolean areEqual(@NotNull TypeMirror typeMirror1, @NotNull TypeMirror typeMirror2) {
         return getUtils().isSameType(typeMirror1, typeMirror2);
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -165,6 +165,18 @@ public final class TypeUtils {
     }
 
     /**
+     * TypeMirrors should not be compared directly, but should use
+     * {@link Types} in order to compare them.
+     *
+     * @param typeMirror1 the first type to compare.
+     * @param typeMirror2 the second type to compare.
+     * @return true if they are equal, false otherwise.
+     */
+    public static boolean areEqual(@Nullable TypeMirror typeMirror1, @Nullable TypeMirror typeMirror2) {
+        return getUtils().isSameType(typeMirror1, typeMirror2);
+    }
+
+    /**
      * Determines whether or not the Element is a concrete type.
      * If the element is a generic type or contains generic type
      * arguments, this method will return false.

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.java
@@ -143,7 +143,7 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
                 assertTrue(entry.getValue()
                                    .toString()
                                    .equals(types.getDeclaredType(Utils.getElementFromClass(ArrayList.class),
-                                           stringType).toString()));
+                                                                 stringType).toString()));
 
             } else if (entry.getKey().createGetterCode().contentEquals("testMap = ")) {
 
@@ -162,15 +162,15 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
                 TypeMirror listString = types.getDeclaredType(Utils.getElementFromClass(List.class), stringType);
 
                 assertTrue(entry.getValue()
-                        .toString()
-                        .equals(types.getDeclaredType(Utils.getElementFromClass(HashMap.class), stringType, listString)
-                                .toString()));
+                                   .toString()
+                                   .equals(types.getDeclaredType(Utils.getElementFromClass(HashMap.class), stringType, listString)
+                                                   .toString()));
             } else if (entry.getKey().createGetterCode().contentEquals("testListMap = ")) {
                 TypeMirror mapStringString = types.getDeclaredType(Utils.getElementFromClass(Map.class), stringType, stringType);
                 assertTrue(entry.getValue()
-                        .toString()
-                        .equals(types.getDeclaredType(Utils.getElementFromClass(ArrayList.class), mapStringString)
-                                .toString()));
+                                   .toString()
+                                   .equals(types.getDeclaredType(Utils.getElementFromClass(ArrayList.class), mapStringString)
+                                                   .toString()));
             }
         }
     }
@@ -187,6 +187,20 @@ public class TypeUtilsUnitTest extends BaseUnitTest {
         assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(DummyMapClass.class)));
         assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(Object.class)));
         assertFalse(TypeUtils.isEnum(Utils.getElementFromClass(String.class)));
+    }
+
+    @Test
+    public void areEqual_isCorrect() {
+        assertTrue(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(Object.class), Utils.getTypeMirrorFromClass(Object.class)));
+        assertTrue(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(String.class), Utils.getTypeMirrorFromClass(String.class)));
+        assertTrue(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(List.class), Utils.getTypeMirrorFromClass(List.class)));
+
+        assertFalse(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(Object.class), Utils.getTypeMirrorFromClass(String.class)));
+        assertFalse(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(String.class), Utils.getTypeMirrorFromClass(List.class)));
+        assertFalse(TypeUtils.areEqual(Utils.getTypeMirrorFromClass(List.class), Utils.getTypeMirrorFromClass(ArrayList.class)));
+
+        assertTrue(TypeUtils.areEqual(Utils.getParameterizedClass(List.class, String.class), Utils.getParameterizedClass(List.class, String.class)));
+        assertFalse(TypeUtils.areEqual(Utils.getParameterizedClass(List.class, String.class), Utils.getParameterizedClass(List.class, Integer.class)));
     }
 
     @Test

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/Utils.java
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/Utils.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -83,6 +84,25 @@ final class Utils {
         assertTrue(exceptionThrown);
     }
 
+    /**
+     * Gets the parameterized class with the given parameters.
+     *
+     * @param clazz      the class to parameterize.
+     * @param parameters the parameters to use.
+     * @return the declared type mirror with the correct type parameters.
+     */
+    @NotNull
+    public static DeclaredType getParameterizedClass(@NotNull Class clazz, @NotNull Class... parameters) {
+        TypeElement rootType = safeElements().getTypeElement(clazz.getName());
+        TypeMirror[] params = new TypeMirror[parameters.length];
+
+        for (int n = 0; n < parameters.length; n++) {
+            params[n] = safeElements().getTypeElement(parameters[n].getName()).asType();
+        }
+
+        return safeTypes().getDeclaredType(rootType, params);
+    }
+
     @Nullable
     public static TypeElement getElementFromClass(@NotNull Class clazz) {
         return safeElements().getTypeElement(clazz.getName());
@@ -108,13 +128,13 @@ final class Utils {
     @NotNull
     public static TypeMirror getGenericVersionOfClass(@NotNull Class clazz) {
         List<? extends TypeParameterElement> params =
-            safeElements().getTypeElement(clazz.getName()).getTypeParameters();
+                safeElements().getTypeElement(clazz.getName()).getTypeParameters();
         TypeMirror[] genericTypes = new TypeMirror[params.size()];
         for (int n = 0; n < genericTypes.length; n++) {
             genericTypes[n] = params.get(n).asType();
         }
         return safeTypes().getDeclaredType(safeElements().getTypeElement(DummyGenericClass.class.getName()),
-            genericTypes);
+                                           genericTypes);
     }
 
 }


### PR DESCRIPTION
#### Ticket
https://github.com/vimeo/stag-java/issues/120

#### Ticket Summary
See https://github.com/vimeo/stag-java/issues/120

#### Implementation Summary
I replaced usage of `typeMirror1.equals(typeMirror2)` with `Types.isSameType(typeMirror1, typeMirror2)` as is suggested in this OpenJDK issue https://bugs.openjdk.java.net/browse/JDK-6498938

I also modified the `sample-java` model to handle this test case.

I also improved error messaging around the private member variable compilation failures.

#### How to Test
Run the tests.
