### PR TITLE
Version 2.3.2 Prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 2.3.2 *(2017-07-14)*
+----------------------------
+- Fixed a bug where stag was unable to find setters/getters for parameterized private fields.
+- Found solution for model list file being included in build (refer to README).
+
 Version 2.3.1 *(2017-06-27)*
 ----------------------------
 - Stag is now being deployed to Maven Central.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ buildscript {
 apply plugin: 'net.ltgt.apt'
 
 dependencies {
-    compile 'com.vimeo.stag:stag-library:2.3.1'
-    apt 'com.vimeo.stag:stag-library-compiler:2.3.1'
+    compile 'com.vimeo.stag:stag-library:2.3.2'
+    apt 'com.vimeo.stag:stag-library-compiler:2.3.2'
 }
 
 // Optional annotation processor arguments (see below)
@@ -67,8 +67,8 @@ apt {
 
 ```groovy
 dependencies {
-    compile 'com.vimeo.stag:stag-library:2.3.1'
-    annotationProcessor 'com.vimeo.stag:stag-library-compiler:2.3.1'
+    compile 'com.vimeo.stag:stag-library:2.3.2'
+    annotationProcessor 'com.vimeo.stag:stag-library-compiler:2.3.2'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,5 @@ allprojects {
 
 subprojects {
     group = 'com.vimeo.stag'
-    version = '2.3.1'
+    version = '2.3.2'
 }


### PR DESCRIPTION
Version 2.3.2 Prep
- Fixed a bug where stag was unable to find setters/getters for parameterized private fields.
- Found solution for model list file being included in build (refer to README).