### PR TITLE
Fixing empty object for null values

### DIFF
--- a/sample-java-model/src/main/java/com/vimeo/sample_java_model/NullFields.java
+++ b/sample-java-model/src/main/java/com/vimeo/sample_java_model/NullFields.java
@@ -1,0 +1,36 @@
+package com.vimeo.sample_java_model;
+
+import com.google.gson.annotations.SerializedName;
+import com.vimeo.stag.UseStag;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A test case for an object containing null fields.
+ * <p>
+ * Created by restainoa on 10/20/17.
+ */
+@UseStag
+public class NullFields {
+
+    @Nullable
+    @SerializedName("hello")
+    public Object hello;
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        NullFields that = (NullFields) o;
+
+        return hello != null ? hello.equals(that.hello) : that.hello == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return hello != null ? hello.hashCode() : 0;
+    }
+}

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.8.0'
     testCompile 'com.google.testing.compile:compile-testing:0.12'
+    testCompile project(path: ':sample-java-model')
 
     // Forcibly add test resources to test classpath: https://code.google.com/p/android/issues/detail?id=64887
     testRuntime files('build/resources/test')

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -724,11 +724,11 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 .addAnnotation(Override.class)
                 .addException(IOException.class);
 
-        builder.addStatement("writer.beginObject()");
         builder.beginControlFlow("if (object == null)");
-        builder.addStatement("writer.endObject()");
+        builder.addStatement("writer.nullValue()");
         builder.addStatement("return");
         builder.endControlFlow();
+        builder.addStatement("writer.beginObject()");
 
         for (Map.Entry<FieldAccessor, TypeMirror> element : memberVariables.entrySet()) {
             FieldAccessor fieldAccessor = element.getKey();

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorFunctionalTest.kt
@@ -45,7 +45,7 @@ class StagProcessorFunctionalTest {
      */
     @Test
     fun privateFieldsNoSettersOrGettersInAnnotatedClassReportsAsAnError() {
-        assertThat(processorTester.compileResource("testcase/FinalFields.java").isSuccessful()).isFalse()
+        assertThat(processorTester.compileResource("testcase/PrivateFields.java").isSuccessful()).isFalse()
     }
 
     @Test

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
@@ -1,0 +1,29 @@
+package com.vimeo.stag.processor
+
+import com.google.gson.Gson
+import com.vimeo.sample_java_model.NullFields
+import com.vimeo.sample_java_model.stag.generated.Stag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * Integration tests for the compiler.
+ *
+ * Created by restainoa on 10/20/17.
+ */
+class StagProcessorIntegrationTest {
+
+    @Test
+    fun `NullFields type adapter is correct for null values`() {
+        val typeAdapter = Stag.Factory().`getNullFields$TypeAdapter`(Gson())
+        val nullFields = NullFields()
+        val json = typeAdapter.toJson(nullFields)
+
+        // Assert that we are getting the JSON we expect
+        assertThat(json).isEqualTo("{}")
+        assertThat(typeAdapter.fromJson(json)).isEqualTo(nullFields)
+
+        // Assert that a null value emits null JSON
+        assertThat(typeAdapter.toJson(null)).isEqualTo("null")
+    }
+}

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -419,13 +419,15 @@ public final class KnownTypeAdapters {
 
         @Override
         public void write(JsonWriter writer, T[] value) throws IOException {
-            writer.beginArray();
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
+                writer.beginArray();
                 for (T item : value) {
                     mValueTypeAdapter.write(writer, item);
                 }
+                writer.endArray();
             }
-            writer.endArray();
         }
 
         @Override
@@ -463,7 +465,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable int[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (int item : value) {
                     writer.value(item);
@@ -496,7 +500,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable long[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (long item : value) {
                     writer.value(item);
@@ -529,7 +535,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable double[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (double item : value) {
                     writer.value(item);
@@ -562,7 +570,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable short[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (short item : value) {
                     writer.value(item);
@@ -595,7 +605,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable float[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (float item : value) {
                     writer.value(item);
@@ -628,7 +640,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable boolean[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (boolean item : value) {
                     writer.value(item);
@@ -661,7 +675,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable byte[] value) throws IOException {
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 writer.beginArray();
                 for (byte item : value) {
                     writer.value(item);
@@ -696,7 +712,9 @@ public final class KnownTypeAdapters {
         }
 
         public static void write(@NotNull JsonWriter writer, @Nullable char[] value) throws IOException {
-            if (value != null) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
                 String string = String.valueOf(value);
                 STRING_NULL_SAFE_TYPE_ADAPTER.write(writer, string);
             }
@@ -804,13 +822,15 @@ public final class KnownTypeAdapters {
 
         @Override
         public void write(JsonWriter writer, T value) throws IOException {
-            writer.beginArray();
-            if (null != value) {
+            if (value == null) {
+                writer.nullValue();
+            } else {
+                writer.beginArray();
                 for (V item : value) {
                     valueTypeAdapter.write(writer, item);
                 }
+                writer.endArray();
             }
-            writer.endArray();
         }
 
         @Override
@@ -856,7 +876,7 @@ public final class KnownTypeAdapters {
 
         @Override
         public void write(JsonWriter writer, T value) throws IOException {
-            if (null == value) {
+            if (value == null) {
                 writer.nullValue();
                 return;
             }


### PR DESCRIPTION
#### Issue
- https://github.com/vimeo/stag-java/issues/132

#### Summary
Previously, when stag encountered a null value when writing objects to json, it would write an empty object. This behavior is erroneous because a field could be annotated `Nullable`, but the field type could have `NonNull` fields. This means that the following valid objects could cause exceptions to be thrown when reading the object out of JSON:

```java
class NullableFieldExample {
    @Nullable public MyObject myObject;
}

class MyObject {
    @NonNull public String title;
}
```
For the following object
```java
NullableFieldExample object = new NullableFieldExample();
object.myObject = null;
gson.toJson(object);
```
the following JSON will be produced.
```json
{
"myObject": {}
}
```
If we attempt to read this object out of JSON, we will get an exception because the field `title` will be null.

Based on the implications of these changes, I would suggest that the next version of stag receive a minor version bump to 2.4.0.

#### How to Test
Test examples, run tests.