### PR TITLE
Resolve #153 by moving suppressing across the entire generated TA class

### DIFF
--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/RawGenericField.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/RawGenericField.java
@@ -1,0 +1,15 @@
+package com.vimeo.sample_java_model;
+
+import com.vimeo.stag.UseStag;
+
+/**
+ * Model which references a generically typed object without generic bounds (i.e., as a raw
+ * type).
+ */
+@UseStag
+public class RawGenericField {
+
+    @SuppressWarnings("rawtypes")
+    public ExternalModelGeneric rawTypedField;
+
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -511,15 +511,15 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         List<? extends TypeMirror> typeArguments = mInfo.getTypeArguments();
 
         MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder()
-                .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                        .addMember("value", "\"unchecked\"")
-                        .addMember("value", "\"rawtypes\"")
-                        .build())
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(Gson.class, "gson");
 
         String className = FileGenUtils.unescapeEscapedString(mInfo.getTypeAdapterClassName());
         TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(className)
+                .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
+                        .addMember("value", "\"unchecked\"")
+                        .addMember("value", "\"rawtypes\"")
+                        .build())
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .superclass(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeVariableName));
 


### PR DESCRIPTION
If the solution is not applied then the RawGenericField class will cause
the compilation warning to be promoted to an error, failing the
integration-test-java module.

#### Issue

https://github.com/vimeo/stag-java/issues/153

#### Summary

Moves suppression annotations from the constructor up to the class level.

We could alternately add them to the field definitions but I fear we'll end up with these issues propagating to another location within the generated code if we find new ways to exercise this.

#### How to Test
Build the project and inspect com.vimeo.sample_java_model.RawGenericField$TypeAdapter source.