### PR TITLE
#155 Rough implementation of wildcard generics forwarding to Gson

### DIFF
--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModel.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModel.java
@@ -1,0 +1,27 @@
+package com.vimeo.sample_java_model;
+
+import com.google.gson.reflect.TypeToken;
+import com.vimeo.stag.UseStag;
+
+@UseStag
+public class DynamicallyTypedModel<T> {
+
+    public Types type;
+    public T value;
+
+    public enum Types {
+        string(new TypeToken<DynamicallyTypedModel<String>>() {}),
+        integer(new TypeToken<DynamicallyTypedModel<Integer>>() {});
+
+        private final TypeToken<?> typeToken;
+
+        Types(TypeToken<?> propertyTypeToken)
+        {
+            this.typeToken = propertyTypeToken;
+        }
+
+        public TypeToken<?> getTypeToken() {
+            return typeToken;
+        }
+    }
+}

--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModelTypeAdapter.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModelTypeAdapter.java
@@ -1,0 +1,78 @@
+package com.vimeo.sample_java_model;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link TypeAdapter} implementation which unmarshals into a {@link JsonObject}, consults the {@code type}
+ * name/value pair to determine the expected value type, then unmarshals the {@link JsonObject} into the
+ * parameterized type specified.  This is is effectively a customized form of:
+ *
+ * https://github.com/google/gson/blob/master/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+ *
+ * @param <T> value type
+ */
+class DynamicallyTypedModelTypeAdapter<T> extends TypeAdapter<T>
+{
+
+	private static final String TYPE_PROPERTY = "type";
+
+	private final AtomicReference<TypeAdapter<JsonObject>> objectDelegateRef = new AtomicReference<>();
+
+	private final Gson gson;
+	private final TypeAdapterFactory skipPast;
+	private final TypeAdapter<T> delegate;
+
+	DynamicallyTypedModelTypeAdapter(
+		Gson gson,
+		TypeAdapterFactory skipPast,
+		TypeAdapter<T> delegate)
+	{
+		this.gson = gson;
+		this.skipPast = skipPast;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void write(JsonWriter out, T value) throws IOException
+	{
+		delegate.write(out, value);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T read(JsonReader in) throws IOException
+	{
+		TypeAdapter<JsonObject> objectDelegate = objectDelegateRef.get();
+		if (objectDelegate == null)
+		{
+			objectDelegate = gson.getAdapter(TypeToken.get(JsonObject.class));
+			objectDelegateRef.compareAndSet(null, objectDelegate);
+		}
+
+		JsonObject jsonObject = objectDelegate.read(in);
+		JsonElement typeElement = jsonObject == null ? null : jsonObject.get(TYPE_PROPERTY);
+		String typeString = typeElement == null ? null : typeElement.getAsString();
+
+		TypeToken<?> parameterizedType;
+		try {
+			DynamicallyTypedModel.Types propertyType = DynamicallyTypedModel.Types.valueOf(typeString);
+			parameterizedType = propertyType.getTypeToken();
+		} catch (IllegalArgumentException e) {
+			throw new IOException("Type not registered: " + typeString, e);
+		}
+
+		TypeAdapter<?> adapter = gson.getDelegateAdapter(skipPast, parameterizedType);
+		return (T) adapter.fromJsonTree(jsonObject);
+	}
+
+}

--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModelTypeAdapterFactory.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedModelTypeAdapterFactory.java
@@ -1,0 +1,50 @@
+package com.vimeo.sample_java_model;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+
+/**
+ * {@link TypeAdapterFactory} implementation which looks for non-parameterized references to {@link DynamicallyTypedModel}
+ * and configures the {@link DynamicallyTypedModelTypeAdapter} for the point of use.  Parameterized references are handled
+ * automagically by Gson.
+ */
+class DynamicallyTypedModelTypeAdapterFactory implements TypeAdapterFactory
+{
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> typeToken)
+	{
+		Class<? super T> rawType = typeToken.getRawType();
+		if (!DynamicallyTypedModel.class.isAssignableFrom(rawType))
+			return null;
+
+		Type type = typeToken.getType();
+		if (isTypeDataPresent(type))
+			return null;
+
+		final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, typeToken);
+		return new DynamicallyTypedModelTypeAdapter<>(gson, this, delegate);
+	}
+
+	private boolean isTypeDataPresent(Type type) {
+		if (type instanceof ParameterizedType) {
+			ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+            for (Type typeArgument : typeArguments) {
+                if (typeArgument instanceof WildcardType) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+			return false;
+		}
+	}
+}

--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedWildcardReadModel.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/DynamicallyTypedWildcardReadModel.java
@@ -1,0 +1,15 @@
+package com.vimeo.sample_java_model;
+
+import com.vimeo.stag.UseStag;
+
+import java.util.List;
+
+/**
+ * Model which references a generically typed object using wildcard bounds.
+ */
+@UseStag
+public class DynamicallyTypedWildcardReadModel {
+
+    public List<DynamicallyTypedModel<?>> models;
+
+}

--- a/integration-test-java/src/test/java/com/vimeo/sample_java_model/DynamicallyTypedModelTest.java
+++ b/integration-test-java/src/test/java/com/vimeo/sample_java_model/DynamicallyTypedModelTest.java
@@ -1,0 +1,52 @@
+package com.vimeo.sample_java_model;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.vimeo.sample_java_model.stag.generated.Stag;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link DynamicallyTypedWildcardReadModel}.
+ */
+public class DynamicallyTypedModelTest {
+
+    @Test
+    public void verifyTypeAdapterWasGenerated_DynamicallyTypedWildcardReadModel() throws Exception {
+        Utils.verifyTypeAdapterGeneration(DynamicallyTypedWildcardReadModel.class);
+    }
+
+    @Test
+    public void verifyTypeAdapterWasGenerated_DynamicallyTypedModel() throws Exception {
+        Utils.verifyTypeAdapterGeneration(DynamicallyTypedModel.class);
+    }
+
+    @Test
+    public void verifyUnmarshalWildcardedTypes() throws Exception {
+
+        final Gson gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new Stag.Factory())
+                .registerTypeAdapterFactory(new DynamicallyTypedModelTypeAdapterFactory())
+                .create();
+
+        String json = "{\"models\":[" +
+                        "{\"type\":\"string\",\"value\":\"value1\"}," +
+                        "{\"type\":\"integer\",\"value\":42}" +
+                        "]}";
+        DynamicallyTypedWildcardReadModel dynamicModel = gson.fromJson(json, DynamicallyTypedWildcardReadModel.class);
+
+        assertEquals(2, dynamicModel.models.size());
+
+        DynamicallyTypedModel<?> stringModel = dynamicModel.models.get(0);
+        assertEquals(DynamicallyTypedModel.Types.string, stringModel.type);
+        assertEquals("value1", stringModel.value);
+
+        DynamicallyTypedModel<?> integerModel = dynamicModel.models.get(1);
+        assertEquals(DynamicallyTypedModel.Types.integer, integerModel.type);
+        assertEquals(Integer.class, integerModel.value.getClass());
+        assertEquals(42, integerModel.value);
+    }
+
+}


### PR DESCRIPTION

#### Issue
- https://github.com/vimeo/stag-java/issues/155

#### Summary

Identifies fields which leverage wildcarded generics and:
- Prevents them from generating mTypeAdapterN fields
- write calls uses the actual field type of the written object
- read calls use reflection to determine field type at runtime

This commit still needs work and testing.

#### How to Test

Test included.

Work needed:
- More tests covering field access in super-classes / sub-classes
- Possibly pull read and write- time TypeAdapter lookups up to the method level so that the lookups can be shared if multiple fields share the same type.  Or possibly up to the constructor level for the read-time ones?  I fear pulling up the write-time ones since it may have more info about the types at runtime and it may vary per call.  Not sure how that interacts with erasure yet...
