### PR TITLE
Code Cleanup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: develop

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-    ext.kotlinVersion = '1.2.20'
+    ext.kotlinVersion = '1.2.21'
     ext.jacocoVersion = '0.7.9' // See http://www.eclemma.org/jacoco/
     ext.gsonVersion = '2.8.2'
 

--- a/integration-test-android/src/main/AndroidManifest.xml
+++ b/integration-test-android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest
-    package="com.vimeo.integration_test_android"
-    xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest package="com.vimeo.integration_test_android" />

--- a/integration-test-java-cross-module/src/main/AndroidManifest.xml
+++ b/integration-test-java-cross-module/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest
-    package="com.vimeo.sample.integration_test_android"
-    xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest package="com.vimeo.sample.integration_test_android" />

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/NestedClass.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/NestedClass.java
@@ -14,6 +14,7 @@ public class NestedClass {
      * classes to explicitly specify the annotation in order to enable generation.
      */
     public static class NestedExtension extends NestedClass {
+
         String field;
     }
 

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/ObjectExample.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/ObjectExample.java
@@ -4,7 +4,6 @@ import com.vimeo.stag.UseStag;
 
 /**
  * Example where Object is one of the member variables
- *
  */
 @UseStag
 public class ObjectExample {

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/OuterClassWithInnerModel.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/OuterClassWithInnerModel.java
@@ -8,10 +8,10 @@ import com.vimeo.stag.UseStag;
  */
 public class OuterClassWithInnerModel {
 
-	@UseStag
-	public static class InnerModel {
+    @UseStag
+    public static class InnerModel {
 
-		public int version;
+        public int version;
 
-	}
+    }
 }

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/SubClassWithSameVariableName.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/SubClassWithSameVariableName.java
@@ -4,6 +4,7 @@ import com.vimeo.stag.UseStag;
 
 import java.util.ArrayList;
 
+@SuppressWarnings("FieldNameHidesFieldInSuperclass")
 @UseStag
 public class SubClassWithSameVariableName extends ClassWithArrayTypes {
 

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/json_adapter/TestDeserializer.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model/json_adapter/TestDeserializer.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Type;
  */
 
 public class TestDeserializer implements JsonDeserializer<BasicModel2> {
+
     @Override
     public BasicModel2 deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         return context.deserialize(json, BasicModel2.class);

--- a/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model1/ParameterizedData.java
+++ b/integration-test-java-cross-module/src/main/java/com/vimeo/sample/model1/ParameterizedData.java
@@ -7,6 +7,7 @@ import java.util.List;
 /**
  * Since this class is not annotated with @UseStag, this will use TypeToken for its adapter generation.
  * As it is of paramterized type, this will use TypeToken.getParameterized() instead of TypeToken.get()
+ *
  * @param <T>
  */
 public class ParameterizedData<T> {

--- a/integration-test-java-cross-module/src/test/java/com/vimeo/sample/model/ObjectExampleTest.java
+++ b/integration-test-java-cross-module/src/test/java/com/vimeo/sample/model/ObjectExampleTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
  * Created by anshul.garg on 12/04/17.
  */
 public class ObjectExampleTest {
+
     @Test
     public void typeAdapterWasGenerated() throws Exception {
         Utils.verifyTypeAdapterGeneration(ObjectExample.class);

--- a/integration-test-java-cross-module/src/test/java/com/vimeo/sample/model/json_adapter/JsonAdapterExampleTest.java
+++ b/integration-test-java-cross-module/src/test/java/com/vimeo/sample/model/json_adapter/JsonAdapterExampleTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
  * Created by anshul.garg on 03/03/17.
  */
 public class JsonAdapterExampleTest {
+
     @Test
     public void typeAdapterWasGenerated() throws Exception {
         Utils.verifyTypeAdapterGeneration(JsonAdapterExample.class);

--- a/integration-test-java/src/main/java/com/vimeo/sample_java_model/NativeJavaModel.java
+++ b/integration-test-java/src/main/java/com/vimeo/sample_java_model/NativeJavaModel.java
@@ -17,6 +17,7 @@ public class NativeJavaModel {
 
     @UseStag
     public static class Nested {
+
         private String mNested;
 
         public String getNested() {
@@ -29,6 +30,7 @@ public class NativeJavaModel {
     }
 
     public static class NestedWithoutAnnotation {
+
         private String mNestedWithoutAnnotation;
 
         public String getNestedWithoutAnnotation() {
@@ -42,6 +44,7 @@ public class NativeJavaModel {
 
     @UseStag
     public static class NestedExtension extends NativeJavaModel {
+
         private String mNestedExtension;
 
         public String getNestedExtension() {
@@ -54,6 +57,7 @@ public class NativeJavaModel {
     }
 
     public static class NestedExtensionWithoutAnnotation extends NativeJavaModel {
+
         private String mNestedExtensionWithoutAnnotation;
 
         public String getNestedExtensionWithoutAnnotation() {
@@ -67,6 +71,7 @@ public class NativeJavaModel {
 
     @UseStag
     public static class NestedExtensionFromNoAnnotation extends NestedWithoutAnnotation {
+
         private String mNestedExtensionFromNoAnnotation;
 
         public String getNestedExtensionFromNoAnnotation() {

--- a/integration-test-java/src/test/java/com/vimeo/sample_java_model/SwappableParserExampleModelTest.java
+++ b/integration-test-java/src/test/java/com/vimeo/sample_java_model/SwappableParserExampleModelTest.java
@@ -55,6 +55,7 @@ public class SwappableParserExampleModelTest {
     /**
      * Stag does support being used across Gson instances now
      */
+    @Test
     public void test_SwappingTypeAdapters() {
 
         final Stag.Factory factory = new Stag.Factory();

--- a/integration-test-java/src/test/java/com/vimeo/sample_java_model/WrapperTypeAdapterModelTest.java
+++ b/integration-test-java/src/test/java/com/vimeo/sample_java_model/WrapperTypeAdapterModelTest.java
@@ -8,13 +8,12 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.vimeo.sample_java_model.WrapperTypeAdapterModel.InnerType;
+import com.vimeo.sample_java_model.stag.generated.Stag;
 
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.vimeo.sample_java_model.stag.generated.Stag;
 
 import static org.junit.Assert.assertEquals;
 

--- a/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/KotlinSamplesTest.kt
+++ b/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/KotlinSamplesTest.kt
@@ -9,7 +9,8 @@ import org.junit.Test
  */
 class KotlinSamplesTest {
 
-    @Test fun verifyTypeAdapterGenerated() {
+    @Test
+    fun verifyTypeAdapterGenerated() {
         Utils.verifyTypeAdapterGeneration(KotlinSamples::class)
     }
 

--- a/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/Utils.kt
+++ b/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/Utils.kt
@@ -7,6 +7,7 @@ import junit.framework.Assert
 import junit.framework.Assert.assertEquals
 import uk.co.jemos.podam.api.PodamFactoryImpl
 import kotlin.reflect.KClass
+import com.vimeo.sample_kotlin.stag.generated.Stag
 
 /**
  * Created by restainoa on 5/8/17.

--- a/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/Utils.kt
+++ b/integration-test-kotlin/src/test/kotlin/com/vimeo/dummy/sample_kotlin/Utils.kt
@@ -3,7 +3,6 @@ package com.vimeo.dummy.sample_kotlin
 import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.reflect.TypeToken
-import com.vimeo.sample_kotlin.stag.generated.Stag
 import junit.framework.Assert
 import junit.framework.Assert.assertEquals
 import uk.co.jemos.podam.api.PodamFactoryImpl

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,8 +21,8 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                        stagGeneratedPackageName: 'com.vimeo.sample.stag.generated',
-                        stagDebug               : 'true',
+                        stagGeneratedPackageName   : 'com.vimeo.sample.stag.generated',
+                        stagDebug                  : 'true',
                         stagAssumeHungarianNotation: 'true'
                 ]
             }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools"
+<manifest
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.vimeo.sample"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -15,9 +16,9 @@
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity android:name=".MainActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/sample/src/main/java/com/vimeo/sample/MainActivity.java
+++ b/sample/src/main/java/com/vimeo/sample/MainActivity.java
@@ -49,9 +49,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        final ListView listView = (ListView) findViewById(R.id.list_view);
-        final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress_bar);
-        final TextView errorText = (TextView) findViewById(R.id.error_text);
+        final ListView listView = findViewById(R.id.list_view);
+        final ProgressBar progressBar = findViewById(R.id.progress_bar);
+        final TextView errorText = findViewById(R.id.error_text);
 
         if (listView == null || progressBar == null || errorText == null) {
             throw new RuntimeException("Unable to find view");

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/sample/src/main/res/layout/row_layout.xml
+++ b/sample/src/main/res/layout/row_layout.xml
@@ -12,6 +12,6 @@
     <TextView
         android:id="@+id/text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme"
-           parent="Theme.AppCompat.Light.DarkActionBar">
+        parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -24,7 +24,7 @@ jacocoTestReport.dependsOn test
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.assertj:assertj-core:3.8.0'
+    testImplementation 'org.assertj:assertj-core:3.9.0'
     testImplementation 'com.google.testing.compile:compile-testing:0.13'
     testImplementation project(path: ':integration-test-java')
     testImplementation project(path: ':integration-test-java-cross-module')
@@ -35,7 +35,7 @@ dependencies {
     implementation project(':stag-library')
 
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'com.squareup:javapoet:1.9.0'
+    implementation 'com.squareup:javapoet:1.10.0'
     implementation 'com.intellij:annotations:12.0@jar'
     implementation 'com.google.auto.service:auto-service:1.0-rc3'
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -251,7 +251,7 @@ public final class StagProcessor extends AbstractProcessor {
     private void writeTypeSpecToFile(@NotNull TypeSpec typeSpec, @NotNull String packageName) throws IOException {
 
         // Create the Java file
-        JavaFile javaFile = JavaFile.builder(packageName, typeSpec).build();
+        JavaFile javaFile = JavaFile.builder(packageName, typeSpec).indent("    ").build();
 
         Filer filer = processingEnv.getFiler();
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -31,6 +31,7 @@ import com.vimeo.stag.processor.generators.AdapterGenerator;
 import com.vimeo.stag.processor.generators.EnumTypeAdapterGenerator;
 import com.vimeo.stag.processor.generators.StagFactoryGenerator;
 import com.vimeo.stag.processor.generators.StagGenerator;
+import com.vimeo.stag.processor.generators.StagGenerator.SubFactoriesInfo;
 import com.vimeo.stag.processor.generators.TypeAdapterGenerator;
 import com.vimeo.stag.processor.generators.model.AnnotatedClass;
 import com.vimeo.stag.processor.generators.model.ClassInfo;
@@ -201,7 +202,7 @@ public final class StagProcessor extends AbstractProcessor {
                 generatedStagFactoryWrappers.add(new StagGenerator.SubFactoriesInfo(classInfos.get(0), stringListEntry.getKey() + "." + StagFactoryGenerator.NAME));
             }
 
-            generateStagFactory(stagFactoryGenerator, packageName, generatedStagFactoryWrappers);
+            generateStagFactory(packageName, generatedStagFactoryWrappers);
             KnownTypeAdapterFactoriesUtils.writeKnownTypes(processingEnv, packageName, supportedTypes);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -222,8 +223,7 @@ public final class StagProcessor extends AbstractProcessor {
         writeTypeSpecToFile(typeAdapterSpec, packageName);
     }
 
-    private void generateStagFactory(@NotNull StagGenerator stagGenerator,
-                                     @NotNull String packageName, List<StagGenerator.SubFactoriesInfo> generatedStagFactoryWrappers) throws IOException {
+    private void generateStagFactory(@NotNull String packageName, List<SubFactoriesInfo> generatedStagFactoryWrappers) throws IOException {
         // Create the type spec
         TypeSpec typeSpec = StagGenerator.createStagSpec(generatedStagFactoryWrappers);
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -154,11 +154,9 @@ public final class StagProcessor extends AbstractProcessor {
         ElementUtils.initialize(processingEnv.getElementUtils());
         MessagerUtils.initialize(processingEnv.getMessager());
 
-        String stagFactoryGeneratedName = StagGenerator.getGeneratedFactoryClassAndPackage(packageName);
-
         Notation notation = assumeHungarianNotation ? Notation.HUNGARIAN : Notation.STANDARD;
 
-        SupportedTypesModel supportedTypesModel = new SupportedTypesModel(stagFactoryGeneratedName, notation);
+        SupportedTypesModel supportedTypesModel = new SupportedTypesModel(notation);
 
         DebugLog.log("\nBeginning @UseStag annotation processing\n");
 
@@ -227,7 +225,7 @@ public final class StagProcessor extends AbstractProcessor {
     private void generateStagFactory(@NotNull StagGenerator stagGenerator,
                                      @NotNull String packageName, List<StagGenerator.SubFactoriesInfo> generatedStagFactoryWrappers) throws IOException {
         // Create the type spec
-        TypeSpec typeSpec = stagGenerator.createStagSpec(generatedStagFactoryWrappers);
+        TypeSpec typeSpec = StagGenerator.createStagSpec(generatedStagFactoryWrappers);
 
         // Write the type spec to a file
         writeTypeSpecToFile(typeSpec, packageName);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/codegen/SwitchCodeBlockBuilder.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/codegen/SwitchCodeBlockBuilder.java
@@ -1,0 +1,101 @@
+package com.vimeo.stag.processor.codegen;
+
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.CodeBlock.Builder;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An extension of JavaPoet that makes creating switches easier.
+ * <p>
+ * Created by restainoa on 2/21/18.
+ */
+public class SwitchCodeBlockBuilder {
+
+    private final CodeBlock.Builder mCodeBlockBuilder = CodeBlock.builder();
+    private boolean mIsCaseIndented;
+
+    /**
+     * Begins a switch.
+     *
+     * @param switchCode the switch code.
+     * @param args       the arguments for the switch, optional.
+     * @return the builder.
+     */
+    public SwitchCodeBlockBuilder beginSwitch(@NotNull String switchCode, @NotNull Object... args) {
+        mCodeBlockBuilder.beginControlFlow(switchCode, args);
+        return this;
+    }
+
+    /**
+     * Ends the switch.
+     *
+     * @return the builder.
+     */
+    public SwitchCodeBlockBuilder endSwitch() {
+        mCodeBlockBuilder.endControlFlow();
+        return this;
+    }
+
+    /**
+     * Begins a case, taking care of control characters like the colon.
+     *
+     * @param caseCode the case to use.
+     * @param args     the optional arguments.
+     * @return the builder.
+     */
+    public SwitchCodeBlockBuilder beginCase(@NotNull String caseCode, @NotNull Object... args) {
+        if (mIsCaseIndented) {
+            mCodeBlockBuilder.unindent();
+        }
+        mCodeBlockBuilder.add(caseCode + ":\n", args).indent();
+        mIsCaseIndented = true;
+        return this;
+    }
+
+    /**
+     * @see CodeBlock.Builder#addStatement(CodeBlock)
+     */
+    public SwitchCodeBlockBuilder addStatement(@NotNull String caseCode, @NotNull Object... args) {
+        mCodeBlockBuilder.addStatement(caseCode, args);
+        return this;
+    }
+
+    /**
+     * @see CodeBlock.Builder#beginControlFlow(String, Object...)
+     */
+    public SwitchCodeBlockBuilder beginControlFlow(@NotNull String caseCode, @NotNull Object... args) {
+        mCodeBlockBuilder.beginControlFlow(caseCode, args);
+        return this;
+    }
+
+    /**
+     * @see Builder#endControlFlow()
+     */
+    public SwitchCodeBlockBuilder endControlFlow() {
+        mCodeBlockBuilder.endControlFlow();
+        return this;
+    }
+
+    /**
+     * Ends the case with a break.
+     *
+     * @return the builder.
+     */
+    public SwitchCodeBlockBuilder endCase() {
+        mCodeBlockBuilder.addStatement("break").unindent();
+        mIsCaseIndented = false;
+        return this;
+    }
+
+    /**
+     * Builds the code block.
+     *
+     * @return the {@link CodeBlock}.
+     */
+    public CodeBlock build() {
+        return mCodeBlockBuilder.build();
+    }
+
+
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
@@ -87,11 +87,11 @@ public abstract class AdapterGenerator {
     /**
      * Creates a TypeToken field in the generated adapter factory
      *
-     * @param typeMirror Type of class for which typetoken has to be generated
+     * @param typeMirror Type of class for which TypeToken has to be generated
      * @return {@link FieldSpec}
      */
     @NotNull
-    FieldSpec createTypeTokenSpec(@NotNull TypeMirror typeMirror) {
+    static FieldSpec createTypeTokenSpec(@NotNull TypeMirror typeMirror) {
         ParameterizedTypeName typeTokenType = ParameterizedTypeName.get(ClassName.get(TypeToken.class), TypeVariableName.get(typeMirror));
         FieldSpec.Builder typeTokenBuilder = FieldSpec.builder(typeTokenType, "TYPE_TOKEN", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
         typeTokenBuilder.initializer("TypeToken.get(" + typeMirror.toString() + ".class)");

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
@@ -52,11 +52,11 @@ public abstract class AdapterGenerator {
     @NotNull
     static String getJsonName(@NotNull Element element) {
 
-        String name = null != element.getAnnotation(SerializedName.class) ?
-                element.getAnnotation(SerializedName.class).value() :
-                null;
+        String name = element.getAnnotation(SerializedName.class) != null
+                ? element.getAnnotation(SerializedName.class).value()
+                : null;
 
-        if (null == name || name.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             name = element.getSimpleName().toString();
         }
         return name;
@@ -70,9 +70,9 @@ public abstract class AdapterGenerator {
      */
     @Nullable
     static String[] getAlternateJsonNames(@NotNull Element element) {
-        return null != element.getAnnotation(SerializedName.class) ?
-                element.getAnnotation(SerializedName.class).alternate() :
-                null;
+        return element.getAnnotation(SerializedName.class) != null
+                ? element.getAnnotation(SerializedName.class).alternate()
+                : null;
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/AdapterGenerator.java
@@ -86,6 +86,7 @@ public abstract class AdapterGenerator {
 
     /**
      * Creates a TypeToken field in the generated adapter factory
+     *
      * @param typeMirror Type of class for which typetoken has to be generated
      * @return {@link FieldSpec}
      */

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/EnumTypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/EnumTypeAdapterGenerator.java
@@ -64,33 +64,31 @@ public class EnumTypeAdapterGenerator extends AdapterGenerator {
 
     @NotNull
     private static MethodSpec getWriteMethodSpec(@NotNull TypeName typeName) {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("write")
+        return MethodSpec.methodBuilder("write")
                 .addParameter(JsonWriter.class, "writer")
                 .addParameter(typeName, "object")
                 .returns(void.class)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
-                .addException(IOException.class);
-
-        builder.addStatement("writer.value(object == null ? null : CONSTANT_TO_NAME.get(object))");
-        return builder.build();
+                .addException(IOException.class)
+                .addStatement("writer.value(object == null ? null : CONSTANT_TO_NAME.get(object))")
+                .build();
     }
 
     @NotNull
     private static MethodSpec getReadMethodSpec(@NotNull TypeName typeName) {
-        MethodSpec.Builder builder = MethodSpec.methodBuilder("read")
+        return MethodSpec.methodBuilder("read")
                 .addParameter(JsonReader.class, "reader")
                 .returns(typeName)
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
-                .addException(IOException.class);
-
-        builder.beginControlFlow("if (reader.peek() == com.google.gson.stream.JsonToken.NULL)");
-        builder.addStatement("reader.nextNull()");
-        builder.addStatement("return null");
-        builder.endControlFlow();
-        builder.addStatement("return NAME_TO_CONSTANT.get(reader.nextString())");
-        return builder.build();
+                .addException(IOException.class)
+                .beginControlFlow("if (reader.peek() == com.google.gson.stream.JsonToken.NULL)")
+                .addStatement("reader.nextNull()")
+                .addStatement("return null")
+                .endControlFlow()
+                .addStatement("return NAME_TO_CONSTANT.get(reader.nextString())")
+                .build();
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
@@ -14,6 +14,7 @@ import com.vimeo.stag.processor.generators.model.ClassInfo;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.lang.model.element.Modifier;
@@ -26,7 +27,7 @@ public class StagFactoryGenerator {
     private final String fileName;
 
     public StagFactoryGenerator(@NotNull List<ClassInfo> classInfoList, @NotNull String fileName) {
-        this.classInfoList = classInfoList;
+        this.classInfoList = new ArrayList<>(classInfoList);
         this.fileName = fileName;
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
@@ -20,6 +20,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;
 
 public class StagFactoryGenerator {
+
     public static final String NAME = "StagFactory";
     private final List<ClassInfo> classInfoList;
     private final String fileName;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
@@ -23,17 +23,17 @@ import javax.lang.model.type.TypeMirror;
 public class StagFactoryGenerator {
 
     @NotNull public static final String NAME = "StagFactory";
-    @NotNull private final List<ClassInfo> classInfoList;
-    @NotNull private final String fileName;
+    @NotNull private final List<ClassInfo> mClassInfoList;
+    @NotNull private final String mFileName;
 
     public StagFactoryGenerator(@NotNull List<ClassInfo> classInfoList, @NotNull String fileName) {
-        this.classInfoList = new ArrayList<>(classInfoList);
-        this.fileName = fileName;
+        mClassInfoList = new ArrayList<>(classInfoList);
+        mFileName = fileName;
     }
 
     @NotNull
     public TypeSpec getTypeAdapterFactorySpec() {
-        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(fileName)
+        TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(mFileName)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addSuperinterface(TypeAdapterFactory.class)
                 .addMethod(getCreateMethodSpec());
@@ -58,7 +58,7 @@ public class StagFactoryGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addCode("Class<? super T> clazz = type.getRawType();\n");
 
-        for (ClassInfo classInfo : classInfoList) {
+        for (ClassInfo classInfo : mClassInfoList) {
             builder.beginControlFlow("if (clazz == " + classInfo.getClassAndPackage() + ".class)");
             List<? extends TypeMirror> typeArguments = classInfo.getTypeArguments();
             if (typeArguments == null || typeArguments.isEmpty()) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagFactoryGenerator.java
@@ -22,9 +22,9 @@ import javax.lang.model.type.TypeMirror;
 
 public class StagFactoryGenerator {
 
-    public static final String NAME = "StagFactory";
-    private final List<ClassInfo> classInfoList;
-    private final String fileName;
+    @NotNull public static final String NAME = "StagFactory";
+    @NotNull private final List<ClassInfo> classInfoList;
+    @NotNull private final String fileName;
 
     public StagFactoryGenerator(@NotNull List<ClassInfo> classInfoList, @NotNull String fileName) {
         this.classInfoList = new ArrayList<>(classInfoList);
@@ -44,7 +44,7 @@ public class StagFactoryGenerator {
     @NotNull
     private MethodSpec getCreateMethodSpec() {
         TypeVariableName genericType = TypeVariableName.get("T");
-        AnnotationSpec suppressions = AnnotationSpec.builder(SuppressWarnings.class)
+        AnnotationSpec suppressedWarnings = AnnotationSpec.builder(SuppressWarnings.class)
                 .addMember("value", "\"unchecked\"")
                 .addMember("value", "\"rawtypes\"")
                 .build();
@@ -53,7 +53,7 @@ public class StagFactoryGenerator {
                 .addParameter(Gson.class, "gson")
                 .addParameter(ParameterizedTypeName.get(ClassName.get(TypeToken.class), genericType), "type")
                 .returns(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), genericType))
-                .addAnnotation(suppressions)
+                .addAnnotation(suppressedWarnings)
                 .addAnnotation(Override.class)
                 .addModifiers(Modifier.PUBLIC)
                 .addCode("Class<? super T> clazz = type.getRawType();\n");

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -142,7 +142,7 @@ public class StagGenerator {
                 .addModifiers(Modifier.PRIVATE)
                 .addParameter(int.class, "index")
                 .addCode("TypeAdapterFactory typeAdapterFactory = typeAdapterFactoryArray[index];\n" +
-                         "if(null == typeAdapterFactory) {\n" +
+                         "if(typeAdapterFactory == null) {\n" +
                          "   typeAdapterFactory = createTypeAdapterFactory(index);\n" +
                          "   typeAdapterFactoryArray[index] = typeAdapterFactory;\n" +
                          "}\n" +
@@ -172,7 +172,7 @@ public class StagGenerator {
                 .addParameter(String.class, "currentPackageName");
 
         getSubTypeAdapterMethodBuilder.addStatement("Integer index = packageToIndexMap.get(currentPackageName);");
-        getSubTypeAdapterMethodBuilder.beginControlFlow("if(null != index)");
+        getSubTypeAdapterMethodBuilder.beginControlFlow("if(index != null)");
         getSubTypeAdapterMethodBuilder.addStatement("TypeAdapterFactory typeAdapterFactory = getTypeAdapterFactory(index)");
         getSubTypeAdapterMethodBuilder.addStatement("return typeAdapterFactory");
         getSubTypeAdapterMethodBuilder.endControlFlow();
@@ -186,7 +186,7 @@ public class StagGenerator {
             getSubTypeAdapterMethodBuilder.addCode("\tresult = getTypeAdapterFactory(" + subFactoriesInfo.representativeClassInfo.getClassAndPackage() + ".class, " +
                                                    "currentPackageName, " + mapIndex + ");");
             getSubTypeAdapterMethodBuilder.addCode("\n");
-            getSubTypeAdapterMethodBuilder.addCode("\tif(null != result) {");
+            getSubTypeAdapterMethodBuilder.addCode("\tif(result != null) {");
             getSubTypeAdapterMethodBuilder.addCode("\n");
             getSubTypeAdapterMethodBuilder.addStatement("\t\treturn result");
             getSubTypeAdapterMethodBuilder.addCode("\t}\n");
@@ -215,12 +215,12 @@ public class StagGenerator {
 
         createMethodBuilder.addStatement("Class<? super T> clazz = type.getRawType()");
         createMethodBuilder.addStatement("String currentPackageName = getPackageName(clazz)");
-        createMethodBuilder.beginControlFlow("if(null == currentPackageName)");
+        createMethodBuilder.beginControlFlow("if(currentPackageName == null)");
         createMethodBuilder.addStatement("return null");
         createMethodBuilder.endControlFlow();
         createMethodBuilder.addCode("\n");
         createMethodBuilder.addStatement("TypeAdapterFactory typeAdapterFactory = getSubFactory(currentPackageName)");
-        createMethodBuilder.addStatement("return null != typeAdapterFactory ? typeAdapterFactory.create(gson, type) : null");
+        createMethodBuilder.addStatement("return typeAdapterFactory != null ? typeAdapterFactory.create(gson, type) : null");
 
         adapterFactoryBuilder.addMethod(createMethodBuilder.build());
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -104,12 +104,12 @@ public class StagGenerator {
 
         ParameterizedTypeName hashMapOfStringToInteger = ParameterizedTypeName.get(HashMap.class, String.class, Integer.class);
         FieldSpec.Builder packageToIndexMapField = FieldSpec.builder(hashMapOfStringToInteger,
-                "packageToIndexMap", Modifier.FINAL, Modifier.PRIVATE).initializer("new " + hashMapOfStringToInteger.toString() + "( " + generatedStagFactoryWrappers.size() + ")");
+                                                                     "packageToIndexMap", Modifier.FINAL, Modifier.PRIVATE).initializer("new " + hashMapOfStringToInteger.toString() + "( " + generatedStagFactoryWrappers.size() + ")");
         adapterFactoryBuilder.addField(packageToIndexMapField.build());
 
         TypeVariableName typeAdapterFactoryArray = TypeVariableName.get("TypeAdapterFactory[]");
         FieldSpec.Builder typeAdapterFactoryArrayField = FieldSpec.builder(typeAdapterFactoryArray,
-                "typeAdapterFactoryArray", Modifier.FINAL, Modifier.PRIVATE).initializer("new TypeAdapterFactory[" + generatedStagFactoryWrappers.size() + "]");
+                                                                           "typeAdapterFactoryArray", Modifier.FINAL, Modifier.PRIVATE).initializer("new TypeAdapterFactory[" + generatedStagFactoryWrappers.size() + "]");
         adapterFactoryBuilder.addField(typeAdapterFactoryArrayField.build());
 
         MethodSpec.Builder getPackageNameMethodBuilder = MethodSpec.methodBuilder("getPackageName")
@@ -118,8 +118,8 @@ public class StagGenerator {
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                 .addParameter(ParameterizedTypeName.get(ClassName.get(Class.class), genericTypeName), "clazz")
                 .addCode("String name = clazz.getName();\n" +
-                        "int last = name.lastIndexOf('.');\n" +
-                        "return last == -1 ? null : name.substring(0, last);\n");
+                         "int last = name.lastIndexOf('.');\n" +
+                         "return last == -1 ? null : name.substring(0, last);\n");
         adapterFactoryBuilder.addMethod(getPackageNameMethodBuilder.build());
 
         MethodSpec.Builder createTypeAdapterFactoryMethodBuilder = MethodSpec.methodBuilder("createTypeAdapterFactory")
@@ -146,11 +146,11 @@ public class StagGenerator {
                 .addModifiers(Modifier.PRIVATE)
                 .addParameter(int.class, "index")
                 .addCode("TypeAdapterFactory typeAdapterFactory = typeAdapterFactoryArray[index];\n" +
-                        "if(null == typeAdapterFactory) {\n" +
-                        "   typeAdapterFactory = createTypeAdapterFactory(index);\n" +
-                        "   typeAdapterFactoryArray[index] = typeAdapterFactory;\n" +
-                        "}\n" +
-                        "return typeAdapterFactory;\n");
+                         "if(null == typeAdapterFactory) {\n" +
+                         "   typeAdapterFactory = createTypeAdapterFactory(index);\n" +
+                         "   typeAdapterFactoryArray[index] = typeAdapterFactory;\n" +
+                         "}\n" +
+                         "return typeAdapterFactory;\n");
         adapterFactoryBuilder.addMethod(getTypeAdapterFactoryMethodBuilder.build());
 
         MethodSpec.Builder getTypeAdapterMethodBuilder = MethodSpec.methodBuilder("getTypeAdapterFactory")
@@ -160,18 +160,18 @@ public class StagGenerator {
                 .addParameter(String.class, "currentPackageName")
                 .addParameter(int.class, "index")
                 .addCode("String packageName = getPackageName(clazz);\n" +
-                        "packageToIndexMap.put(packageName, index);\n" +
-                        "if(currentPackageName.equals(packageName)) {\n" +
-                        "   return getTypeAdapterFactory(index);\n" +
-                        "}\n" +
-                        "return null;\n");
+                         "packageToIndexMap.put(packageName, index);\n" +
+                         "if(currentPackageName.equals(packageName)) {\n" +
+                         "   return getTypeAdapterFactory(index);\n" +
+                         "}\n" +
+                         "return null;\n");
         adapterFactoryBuilder.addMethod(getTypeAdapterMethodBuilder.build());
 
         MethodSpec.Builder getSubTypeAdapterMethodBuilder = MethodSpec.methodBuilder("getSubFactory")
                 .returns(ClassName.get(TypeAdapterFactory.class))
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                                .addMember("value", "\"fallthrough\"")
-                                .build())
+                                       .addMember("value", "\"fallthrough\"")
+                                       .build())
                 .addModifiers(Modifier.PRIVATE, Modifier.SYNCHRONIZED)
                 .addParameter(String.class, "currentPackageName");
 
@@ -188,7 +188,7 @@ public class StagGenerator {
             getSubTypeAdapterMethodBuilder.addCode("case " + mapIndex + " : ");
             getSubTypeAdapterMethodBuilder.addCode("\n");
             getSubTypeAdapterMethodBuilder.addCode("\tresult = getTypeAdapterFactory(" + subFactoriesInfo.representativeClassInfo.getClassAndPackage() + ".class, " +
-                    "currentPackageName, " + mapIndex + ");");
+                                                   "currentPackageName, " + mapIndex + ");");
             getSubTypeAdapterMethodBuilder.addCode("\n");
             getSubTypeAdapterMethodBuilder.addCode("\tif(null != result) {");
             getSubTypeAdapterMethodBuilder.addCode("\n");
@@ -208,14 +208,14 @@ public class StagGenerator {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override.class)
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                        .addMember(suppressWarningValue, "\"unchecked\"")
-                        .addMember(suppressWarningValue, "\"rawtypes\"")
-                        .build())
+                                       .addMember(suppressWarningValue, "\"unchecked\"")
+                                       .addMember(suppressWarningValue, "\"rawtypes\"")
+                                       .build())
                 .addTypeVariable(genericTypeName)
                 .returns(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), genericTypeName))
                 .addParameter(Gson.class, "gson")
                 .addParameter(ParameterizedTypeName.get(ClassName.get(TypeToken.class), genericTypeName),
-                        "type");
+                              "type");
 
         createMethodBuilder.addStatement("Class<? super T> clazz = type.getRawType()");
         createMethodBuilder.addStatement("String currentPackageName = getPackageName(clazz)");
@@ -232,6 +232,7 @@ public class StagGenerator {
     }
 
     public static class SubFactoriesInfo {
+
         ClassInfo representativeClassInfo;
         String classAndPackageName;
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -69,10 +69,6 @@ public class StagGenerator {
         }
     }
 
-    public static String getGeneratedFactoryClassAndPackage(String generatedPackageName) {
-        return generatedPackageName + "." + CLASS_STAG + "." + CLASS_TYPE_ADAPTER_FACTORY;
-    }
-
     @Nullable
     ClassInfo getKnownClass(@NotNull TypeMirror typeMirror) {
         return mKnownClasses.get(typeMirror.toString());
@@ -86,7 +82,7 @@ public class StagGenerator {
      * @return A non null TypeSpec for the factory class.
      */
     @NotNull
-    public TypeSpec createStagSpec(List<SubFactoriesInfo> generatedStagFactoryWrappers) {
+    public static TypeSpec createStagSpec(List<SubFactoriesInfo> generatedStagFactoryWrappers) {
         TypeSpec.Builder stagBuilder =
                 TypeSpec.classBuilder(CLASS_STAG).addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         stagBuilder.addType(getAdapterFactorySpec(generatedStagFactoryWrappers));
@@ -233,8 +229,8 @@ public class StagGenerator {
 
     public static class SubFactoriesInfo {
 
-        ClassInfo representativeClassInfo;
-        String classAndPackageName;
+        final ClassInfo representativeClassInfo;
+        final String classAndPackageName;
 
         public SubFactoriesInfo(ClassInfo classInfo, String classAndPackageName) {
             this.representativeClassInfo = classInfo;

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -229,10 +229,11 @@ public class StagGenerator {
 
     public static class SubFactoriesInfo {
 
-        final ClassInfo representativeClassInfo;
-        final String classAndPackageName;
+        @NotNull final ClassInfo representativeClassInfo;
 
-        public SubFactoriesInfo(ClassInfo classInfo, String classAndPackageName) {
+        @NotNull final String classAndPackageName;
+
+        public SubFactoriesInfo(@NotNull ClassInfo classInfo, @NotNull String classAndPackageName) {
             this.representativeClassInfo = classInfo;
             this.classAndPackageName = classAndPackageName;
         }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -95,7 +95,7 @@ public class StagGenerator {
     }
 
     @NotNull
-    private TypeSpec getAdapterFactorySpec(@NotNull List<SubFactoriesInfo> generatedStagFactoryWrappers) {
+    private static TypeSpec getAdapterFactorySpec(@NotNull List<SubFactoriesInfo> generatedStagFactoryWrappers) {
         TypeVariableName genericTypeName = TypeVariableName.get("T");
 
         TypeSpec.Builder adapterFactoryBuilder = TypeSpec.classBuilder(CLASS_TYPE_ADAPTER_FACTORY)

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/StagGenerator.java
@@ -113,9 +113,9 @@ public class StagGenerator {
                 .returns(String.class)
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                 .addParameter(ParameterizedTypeName.get(ClassName.get(Class.class), genericTypeName), "clazz")
-                .addCode("String name = clazz.getName();\n" +
-                         "int last = name.lastIndexOf('.');\n" +
-                         "return last == -1 ? null : name.substring(0, last);\n");
+                .addStatement("String name = clazz.getName()")
+                .addStatement("int last = name.lastIndexOf('.')")
+                .addStatement("return last == -1 ? null : name.substring(0, last)");
         adapterFactoryBuilder.addMethod(getPackageNameMethodBuilder.build());
 
         MethodSpec.Builder createTypeAdapterFactoryMethodBuilder = MethodSpec.methodBuilder("createTypeAdapterFactory")
@@ -125,28 +125,28 @@ public class StagGenerator {
                 .addStatement("TypeAdapterFactory result = null")
                 .beginControlFlow("switch(index)");
 
-        int index = 0;
-        for (SubFactoriesInfo subFactoriesInfo : generatedStagFactoryWrappers) {
-            createTypeAdapterFactoryMethodBuilder.addCode("case " + index + " : ");
-            createTypeAdapterFactoryMethodBuilder.addStatement("\t\nresult = new " + subFactoriesInfo.classAndPackageName + "()");
-            createTypeAdapterFactoryMethodBuilder.addCode("\tbreak;\n");
-            index++;
+        for (int index = 0; index < generatedStagFactoryWrappers.size(); index++) {
+            createTypeAdapterFactoryMethodBuilder
+                    .addStatement("case $L : ", index)
+                    .addStatement("result = new $L()", generatedStagFactoryWrappers.get(index).classAndPackageName)
+                    .addStatement("break");
         }
 
-        createTypeAdapterFactoryMethodBuilder.endControlFlow();
-        createTypeAdapterFactoryMethodBuilder.addStatement("return result");
+        createTypeAdapterFactoryMethodBuilder
+                .endControlFlow()
+                .addStatement("return result");
         adapterFactoryBuilder.addMethod(createTypeAdapterFactoryMethodBuilder.build());
 
         MethodSpec.Builder getTypeAdapterFactoryMethodBuilder = MethodSpec.methodBuilder("getTypeAdapterFactory")
                 .returns(TypeAdapterFactory.class)
                 .addModifiers(Modifier.PRIVATE)
                 .addParameter(int.class, "index")
-                .addCode("TypeAdapterFactory typeAdapterFactory = typeAdapterFactoryArray[index];\n" +
-                         "if(typeAdapterFactory == null) {\n" +
-                         "   typeAdapterFactory = createTypeAdapterFactory(index);\n" +
-                         "   typeAdapterFactoryArray[index] = typeAdapterFactory;\n" +
-                         "}\n" +
-                         "return typeAdapterFactory;\n");
+                .addStatement("TypeAdapterFactory typeAdapterFactory = typeAdapterFactoryArray[index]")
+                .beginControlFlow("if (typeAdapterFactory == null)")
+                .addStatement("typeAdapterFactory = createTypeAdapterFactory(index)")
+                .addStatement("typeAdapterFactoryArray[index] = typeAdapterFactory")
+                .endControlFlow()
+                .addStatement("return typeAdapterFactory");
         adapterFactoryBuilder.addMethod(getTypeAdapterFactoryMethodBuilder.build());
 
         MethodSpec.Builder getTypeAdapterMethodBuilder = MethodSpec.methodBuilder("getTypeAdapterFactory")
@@ -155,12 +155,12 @@ public class StagGenerator {
                 .addParameter(ParameterizedTypeName.get(ClassName.get(Class.class), TypeVariableName.get("?")), "clazz")
                 .addParameter(String.class, "currentPackageName")
                 .addParameter(int.class, "index")
-                .addCode("String packageName = getPackageName(clazz);\n" +
-                         "packageToIndexMap.put(packageName, index);\n" +
-                         "if(currentPackageName.equals(packageName)) {\n" +
-                         "   return getTypeAdapterFactory(index);\n" +
-                         "}\n" +
-                         "return null;\n");
+                .addStatement("String packageName = getPackageName(clazz)")
+                .addStatement("packageToIndexMap.put(packageName, index)")
+                .beginControlFlow("if (currentPackageName.equals(packageName))")
+                .addStatement("return getTypeAdapterFactory(index)")
+                .endControlFlow()
+                .addStatement("return null");
         adapterFactoryBuilder.addMethod(getTypeAdapterMethodBuilder.build());
 
         MethodSpec.Builder getSubTypeAdapterMethodBuilder = MethodSpec.methodBuilder("getSubFactory")
@@ -169,33 +169,28 @@ public class StagGenerator {
                                        .addMember("value", "\"fallthrough\"")
                                        .build())
                 .addModifiers(Modifier.PRIVATE, Modifier.SYNCHRONIZED)
-                .addParameter(String.class, "currentPackageName");
+                .addParameter(String.class, "currentPackageName")
+                .addStatement("Integer index = packageToIndexMap.get(currentPackageName);")
+                .beginControlFlow("if (index != null)")
+                .addStatement("TypeAdapterFactory typeAdapterFactory = getTypeAdapterFactory(index)")
+                .addStatement("return typeAdapterFactory")
+                .endControlFlow()
+                .addStatement("TypeAdapterFactory result = null")
+                .beginControlFlow("switch(packageToIndexMap.size())");
 
-        getSubTypeAdapterMethodBuilder.addStatement("Integer index = packageToIndexMap.get(currentPackageName);");
-        getSubTypeAdapterMethodBuilder.beginControlFlow("if(index != null)");
-        getSubTypeAdapterMethodBuilder.addStatement("TypeAdapterFactory typeAdapterFactory = getTypeAdapterFactory(index)");
-        getSubTypeAdapterMethodBuilder.addStatement("return typeAdapterFactory");
-        getSubTypeAdapterMethodBuilder.endControlFlow();
-        getSubTypeAdapterMethodBuilder.addStatement("TypeAdapterFactory result = null");
-        getSubTypeAdapterMethodBuilder.beginControlFlow("switch(packageToIndexMap.size())");
-
-        int mapIndex = 0;
-        for (SubFactoriesInfo subFactoriesInfo : generatedStagFactoryWrappers) {
-            getSubTypeAdapterMethodBuilder.addCode("case " + mapIndex + " : ");
-            getSubTypeAdapterMethodBuilder.addCode("\n");
-            getSubTypeAdapterMethodBuilder.addCode("\tresult = getTypeAdapterFactory(" + subFactoriesInfo.representativeClassInfo.getClassAndPackage() + ".class, " +
-                                                   "currentPackageName, " + mapIndex + ");");
-            getSubTypeAdapterMethodBuilder.addCode("\n");
-            getSubTypeAdapterMethodBuilder.addCode("\tif(result != null) {");
-            getSubTypeAdapterMethodBuilder.addCode("\n");
-            getSubTypeAdapterMethodBuilder.addStatement("\t\treturn result");
-            getSubTypeAdapterMethodBuilder.addCode("\t}\n");
-            mapIndex++;
+        for (int index = 0; index < generatedStagFactoryWrappers.size(); index++) {
+            getSubTypeAdapterMethodBuilder
+                    .addStatement("case $L :", index)
+                    .addStatement("result = getTypeAdapterFactory($L.class, currentPackageName, $L)", generatedStagFactoryWrappers.get(index).representativeClassInfo.getClassAndPackage(), index)
+                    .beginControlFlow("if (result != null)")
+                    .addStatement("return result")
+                    .endControlFlow();
         }
 
-        getSubTypeAdapterMethodBuilder.addCode("default : ");
-        getSubTypeAdapterMethodBuilder.addStatement("\t\nreturn null");
-        getSubTypeAdapterMethodBuilder.endControlFlow();
+        getSubTypeAdapterMethodBuilder
+                .addStatement("default :")
+                .addStatement("return null")
+                .endControlFlow();
 
         adapterFactoryBuilder.addMethod(getSubTypeAdapterMethodBuilder.build());
 
@@ -211,16 +206,15 @@ public class StagGenerator {
                 .returns(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), genericTypeName))
                 .addParameter(Gson.class, "gson")
                 .addParameter(ParameterizedTypeName.get(ClassName.get(TypeToken.class), genericTypeName),
-                              "type");
+                              "type")
 
-        createMethodBuilder.addStatement("Class<? super T> clazz = type.getRawType()");
-        createMethodBuilder.addStatement("String currentPackageName = getPackageName(clazz)");
-        createMethodBuilder.beginControlFlow("if(currentPackageName == null)");
-        createMethodBuilder.addStatement("return null");
-        createMethodBuilder.endControlFlow();
-        createMethodBuilder.addCode("\n");
-        createMethodBuilder.addStatement("TypeAdapterFactory typeAdapterFactory = getSubFactory(currentPackageName)");
-        createMethodBuilder.addStatement("return typeAdapterFactory != null ? typeAdapterFactory.create(gson, type) : null");
+                .addStatement("Class<? super T> clazz = type.getRawType()")
+                .addStatement("String currentPackageName = getPackageName(clazz)")
+                .beginControlFlow("if (currentPackageName == null)")
+                .addStatement("return null")
+                .endControlFlow()
+                .addStatement("TypeAdapterFactory typeAdapterFactory = getSubFactory(currentPackageName)")
+                .addStatement("return typeAdapterFactory != null ? typeAdapterFactory.create(gson, type) : null");
 
         adapterFactoryBuilder.addMethod(createMethodBuilder.build());
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -422,9 +422,9 @@ public class TypeAdapterGenerator extends AdapterGenerator {
     /**
      * Returns the adapter code for the known types.
      */
-    private String getAdapterAccessor(@NotNull TypeMirror fieldType
+    private static String getAdapterAccessor(@NotNull TypeMirror fieldType
             , @NotNull StagGenerator stagGenerator, @NotNull Map<TypeMirror, String> typeVarsMap,
-                                      @NotNull AdapterFieldInfo adapterFieldInfo) {
+                                             @NotNull AdapterFieldInfo adapterFieldInfo) {
 
         String knownTypeAdapter = KnownTypeAdapterUtils.getKnownTypeAdapterForType(fieldType);
 
@@ -499,10 +499,10 @@ public class TypeAdapterGenerator extends AdapterGenerator {
     }
 
     @NotNull
-    private AdapterFieldInfo addAdapterFields(@NotNull StagGenerator stagGenerator,
-                                              @NotNull MethodSpec.Builder constructorBuilder,
-                                              @NotNull Map<FieldAccessor, TypeMirror> memberVariables,
-                                              @NotNull Map<TypeMirror, String> typeVarsMap) {
+    private static AdapterFieldInfo addAdapterFields(@NotNull StagGenerator stagGenerator,
+                                                     @NotNull MethodSpec.Builder constructorBuilder,
+                                                     @NotNull Map<FieldAccessor, TypeMirror> memberVariables,
+                                                     @NotNull Map<TypeMirror, String> typeVarsMap) {
 
         AdapterFieldInfo result = new AdapterFieldInfo(memberVariables.size());
         for (Map.Entry<FieldAccessor, TypeMirror> entry : memberVariables.entrySet()) {
@@ -639,12 +639,9 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
     private static class FieldInfo {
 
-        @NotNull
-        private final TypeMirror type;
-        @NotNull
-        private final String initializationCode;
-        @NotNull
-        private final String accessorVariable;
+        @NotNull final TypeMirror type;
+        @NotNull final String initializationCode;
+        @NotNull final String accessorVariable;
 
         FieldInfo(@NotNull TypeMirror type, @NotNull String initializationCode, @NotNull String accessorVariable) {
             this.type = type;
@@ -660,16 +657,13 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         private final Map<String, String> mAdapterAccessor;
 
         //FieldName -> Accessor Map
-        @NotNull
-        private final Map<String, FieldInfo> mFieldAdapterAccessor;
+        @NotNull final Map<String, FieldInfo> mFieldAdapterAccessor;
 
         //Type.toString -> Accessor Map
-        @NotNull
-        private final Map<String, FieldInfo> mAdapterFields;
+        @NotNull final Map<String, FieldInfo> mAdapterFields;
 
         //Type.toString -> Type Token Accessor Map
-        @NotNull
-        private final Map<String, FieldInfo> mTypeTokenAccessorFields;
+        @NotNull final Map<String, FieldInfo> mTypeTokenAccessorFields;
 
         AdapterFieldInfo(int capacity) {
             mAdapterFields = new LinkedHashMap<>(capacity);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -316,7 +316,8 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 String initializer = adapterType.getEnclosingElement().toString() + " " + varName + " = " +
                                      "new " + adapterType;
                 constructorBuilder.addStatement(initializer);
-                serializer = deserializer = varName;
+                serializer = varName;
+                deserializer = varName;
             } else if (jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER) {
                 serializer = "new " + adapterType;
             } else if (jsonAdapterType == TypeUtils.JsonAdapterType.JSON_DESERIALIZER) {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -133,13 +133,15 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
             int paramIndex = 0;
             for (TypeMirror parameterTypeMirror : typeMirrors) {
-                TypeMirror classArg = null != classArguments && classArguments.size() > paramIndex ? classArguments.get(paramIndex) : null;
-                if (null != classArg) {
+                TypeMirror classArg = classArguments != null && classArguments.size() > paramIndex
+                        ? classArguments.get(paramIndex)
+                        : null;
+                if (classArg != null) {
                     fieldTypeVarsMap.put(classArg, parameterTypeMirror);
                 }
                 if (parameterTypeMirror.getKind() == TypeKind.WILDCARD) {
                     String upperBoundString = "";
-                    if (null != classArg && classArg.getKind() == TypeKind.TYPEVAR) {
+                    if (classArg != null && classArg.getKind() == TypeKind.TYPEVAR) {
                         TypeVariable typeVariable = (TypeVariable) classArg;
                         TypeMirror upperBound = typeVariable.getUpperBound();
                         if (TypeUtils.isParameterizedType(upperBound)) {
@@ -350,7 +352,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                                                           @NotNull AdapterFieldInfo adapterFieldInfo) {
 
         String fieldName = adapterFieldInfo.getFieldName(fieldType);
-        if (null == fieldName) {
+        if (fieldName == null) {
             fieldName = TYPE_ADAPTER_FIELD_PREFIX + adapterFieldInfo.size();
             String fieldInitializationCode = "gson.getAdapter(" +
                                              getTypeTokenCode(fieldType, stagGenerator, typeVarsMap, adapterFieldInfo) + ")";
@@ -429,12 +431,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
         String knownTypeAdapter = KnownTypeAdapterUtils.getKnownTypeAdapterForType(fieldType);
 
-        if (null != knownTypeAdapter) {
+        if (knownTypeAdapter != null) {
             return knownTypeAdapter;
         }
 
         String fieldName = adapterFieldInfo.getFieldName(fieldType);
-        if (null != fieldName) {
+        if (fieldName != null) {
             return fieldName;
         }
 
@@ -533,7 +535,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 adapterAccessor = getAdapterAccessor(fieldType, stagGenerator, typeVarsMap, result);
             }
 
-            if (null != adapterAccessor) {
+            if (adapterAccessor != null) {
                 result.addTypeToAdapterAccessor(fieldType, adapterAccessor);
             }
         }
@@ -571,7 +573,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         Map<TypeMirror, String> typeVarsMap = new HashMap<>();
 
         int idx = 0;
-        if (null != typeArguments) {
+        if (typeArguments != null) {
             for (TypeMirror innerTypeMirror : typeArguments) {
                 if (innerTypeMirror.getKind() == TypeKind.TYPEVAR) {
                     TypeVariable typeVariable = (TypeVariable) innerTypeMirror;
@@ -595,7 +597,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         }
 
         AnnotatedClass annotatedClass = mSupportedTypesModel.getSupportedType(typeMirror);
-        if (null == annotatedClass) {
+        if (annotatedClass == null) {
             throw new IllegalStateException("The AnnotatedClass class can't be null in TypeAdapterGenerator : " + typeMirror.toString());
         }
         Map<FieldAccessor, TypeMirror> memberVariables = annotatedClass.getMemberVariables();
@@ -675,12 +677,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
         String getAdapterAccessor(@NotNull TypeMirror typeMirror, @NotNull String fieldName) {
             FieldInfo adapterAccessor = mFieldAdapterAccessor.get(fieldName);
-            return null != adapterAccessor ? adapterAccessor.accessorVariable : mAdapterAccessor.get(typeMirror.toString());
+            return adapterAccessor != null ? adapterAccessor.accessorVariable : mAdapterAccessor.get(typeMirror.toString());
         }
 
         String updateAndGetTypeTokenFieldName(@NotNull TypeMirror fieldType, @NotNull String initializationCode) {
             FieldInfo result = mTypeTokenAccessorFields.get(fieldType.toString());
-            if (null == result) {
+            if (result == null) {
                 result = new FieldInfo(fieldType, initializationCode, "typeToken" + mTypeTokenAccessorFields.size());
                 mTypeTokenAccessorFields.put(fieldType.toString(), result);
             }
@@ -689,7 +691,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
         String getFieldName(@NotNull TypeMirror fieldType) {
             FieldInfo fieldInfo = mAdapterFields.get(fieldType.toString());
-            return null != fieldInfo ? fieldInfo.accessorVariable : null;
+            return fieldInfo != null ? fieldInfo.accessorVariable : null;
         }
 
         int size() {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/TypeAdapterGenerator.java
@@ -123,7 +123,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             DeclaredType declaredFieldType = (DeclaredType) fieldType;
             List<? extends TypeMirror> typeMirrors = ((DeclaredType) fieldType).getTypeArguments();
             StringBuilder result = new StringBuilder("(com.google.gson.reflect.TypeToken<" + fieldType.toString() + ">)com.google.gson.reflect.TypeToken.getParameterized(" +
-                    declaredFieldType.asElement().toString() + ".class");
+                                                     declaredFieldType.asElement().toString() + ".class");
 
             /*
              * Iterate through all the types from the typeArguments and generate type token code accordingly
@@ -234,12 +234,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
 
             if (isPrimitive) {
                 builder.addStatement("\tobject." +
-                        fieldAccessor.createSetterCode(adapterFieldInfo.getAdapterAccessor(elementValue, name) +
-                                ".read(reader, object." + fieldAccessor.createGetterCode() + ")"));
+                                     fieldAccessor.createSetterCode(adapterFieldInfo.getAdapterAccessor(elementValue, name) +
+                                                                    ".read(reader, object." + fieldAccessor.createGetterCode() + ")"));
 
             } else {
                 builder.addStatement("\tobject." + fieldAccessor.createSetterCode(adapterFieldInfo.getAdapterAccessor(elementValue, name) +
-                        ".read(reader)"));
+                                                                                  ".read(reader)"));
             }
 
 
@@ -307,14 +307,14 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             String typeTokenAccessorCode = getTypeTokenCode(fieldType, stagGenerator, typeVarsMap, adapterFieldInfo);
             fieldAdapterAccessor += "().create(gson, " + typeTokenAccessorCode + ")";
         } else if (jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER
-                || jsonAdapterType == TypeUtils.JsonAdapterType.JSON_DESERIALIZER
-                || jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER_DESERIALIZER) {
+                   || jsonAdapterType == TypeUtils.JsonAdapterType.JSON_DESERIALIZER
+                   || jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER_DESERIALIZER) {
             String serializer = null, deserializer = null;
 
             if (jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER_DESERIALIZER) {
                 String varName = keyFieldName + "SerializerDeserializer";
                 String initializer = adapterType.getEnclosingElement().toString() + " " + varName + " = " +
-                        "new " + adapterType;
+                                     "new " + adapterType;
                 constructorBuilder.addStatement(initializer);
                 serializer = deserializer = varName;
             } else if (jsonAdapterType == TypeUtils.JsonAdapterType.JSON_SERIALIZER) {
@@ -327,7 +327,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         } else {
             throw new IllegalArgumentException(
                     "@JsonAdapter value must be TypeAdapter, TypeAdapterFactory, "
-                            + "JsonSerializer or JsonDeserializer reference.");
+                    + "JsonSerializer or JsonDeserializer reference.");
         }
         String adapterCode = getCleanedFieldInitializer(fieldAdapterAccessor);
         if (isNullSafe) {
@@ -352,7 +352,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         if (null == fieldName) {
             fieldName = TYPE_ADAPTER_FIELD_PREFIX + adapterFieldInfo.size();
             String fieldInitializationCode = "gson.getAdapter(" +
-                    getTypeTokenCode(fieldType, stagGenerator, typeVarsMap, adapterFieldInfo) + ")";
+                                             getTypeTokenCode(fieldType, stagGenerator, typeVarsMap, adapterFieldInfo) + ")";
             adapterFieldInfo.addField(fieldType, fieldName, fieldInitializationCode);
         }
         return fieldName;
@@ -395,7 +395,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             if (!isPrimitive) {
                 builder.addStatement(
                         adapterFieldInfo.getAdapterAccessor(element.getValue(), name) + ".write(writer, object." +
-                                getterCode + ")");
+                        getterCode + ")");
                 /*
                 * If the element is annotated with NonNull annotation, throw {@link IOException} if it is null.
                 */
@@ -446,12 +446,12 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 return KnownTypeAdapterUtils.getNativePrimitiveArrayTypeAdapter(fieldType);
             } else {
                 String adapterAccessor = getAdapterAccessor(arrayInnerType, stagGenerator, typeVarsMap,
-                        adapterFieldInfo);
+                                                            adapterFieldInfo);
                 String nativeArrayInstantiator =
                         KnownTypeAdapterUtils.getNativeArrayInstantiator(arrayInnerType);
                 return "new " + TypeUtils.className(ArrayTypeAdapter.class) + "<" +
-                        arrayInnerType.toString() + ">" +
-                        "(" + adapterAccessor + ", " + nativeArrayInstantiator + ")";
+                       arrayInnerType.toString() + ">" +
+                       "(" + adapterAccessor + ", " + nativeArrayInstantiator + ")";
             }
         } else if (TypeUtils.isSupportedList(fieldType)) {
             DeclaredType declaredType = (DeclaredType) fieldType;
@@ -461,8 +461,8 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             String listInstantiator = KnownTypeAdapterUtils.getListInstantiator(fieldType);
             String adapterCode =
                     "new " + TypeUtils.className(KnownTypeAdapters.ListTypeAdapter.class) + "<" + param.toString() + "," +
-                            fieldType.toString() + ">" +
-                            "(" + paramAdapterAccessor + ", " + listInstantiator + ")";
+                    fieldType.toString() + ">" +
+                    "(" + paramAdapterAccessor + ", " + listInstantiator + ")";
             fieldName = TYPE_ADAPTER_FIELD_PREFIX + adapterFieldInfo.size();
             adapterFieldInfo.addField(fieldType, fieldName, adapterCode);
             return fieldName;
@@ -480,7 +480,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 keyAdapterAccessor = getAdapterAccessor(keyType, stagGenerator, typeVarsMap, adapterFieldInfo);
                 valueAdapterAccessor = getAdapterAccessor(valueType, stagGenerator, typeVarsMap, adapterFieldInfo);
                 arguments = "<" + keyType.toString() + ", " + valueType.toString() + ", " +
-                        fieldType.toString() + ">";
+                            fieldType.toString() + ">";
             } else {
                 // If the map does not have any type arguments, use Object as type params in this case
                 keyAdapterAccessor = "mGson.getAdapter(KnownTypeAdapters.ObjectTypeAdapter.TYPE_TOKEN)";
@@ -488,8 +488,8 @@ public class TypeAdapterGenerator extends AdapterGenerator {
             }
 
             String adapterCode = "new " + TypeUtils.className(KnownTypeAdapters.MapTypeAdapter.class) + arguments +
-                    "(" + keyAdapterAccessor + ", " + valueAdapterAccessor + ", " +
-                    mapInstantiator + ")";
+                                 "(" + keyAdapterAccessor + ", " + valueAdapterAccessor + ", " +
+                                 mapInstantiator + ")";
             fieldName = TYPE_ADAPTER_FIELD_PREFIX + adapterFieldInfo.size();
             adapterFieldInfo.addField(fieldType, fieldName, adapterCode);
             return fieldName;
@@ -516,8 +516,8 @@ public class TypeAdapterGenerator extends AdapterGenerator {
                 if (constructor != null) {
                     TypeUtils.JsonAdapterType jsonAdapterType1 = TypeUtils.getJsonAdapterType(optionalJsonAdapter);
                     String initiazationCode = getInitializationCodeForKnownJsonAdapterType(constructor, stagGenerator,
-                            typeVarsMap, constructorBuilder, fieldType,
-                            jsonAdapterType1, result, fieldAccessor.isJsonAdapterNullSafe(), fieldAccessor.getJsonName());
+                                                                                           typeVarsMap, constructorBuilder, fieldType,
+                                                                                           jsonAdapterType1, result, fieldAccessor.isJsonAdapterNullSafe(), fieldAccessor.getJsonName());
 
                     String fieldName = TYPE_ADAPTER_FIELD_PREFIX + result.size();
                     result.addFieldToAccessor(fieldAccessor.getJsonName(), fieldName, fieldType, initiazationCode);
@@ -561,9 +561,9 @@ public class TypeAdapterGenerator extends AdapterGenerator {
         String className = FileGenUtils.unescapeEscapedString(mInfo.getTypeAdapterClassName());
         TypeSpec.Builder adapterBuilder = TypeSpec.classBuilder(className)
                 .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
-                        .addMember("value", "\"unchecked\"")
-                        .addMember("value", "\"rawtypes\"")
-                        .build())
+                                       .addMember("value", "\"unchecked\"")
+                                       .addMember("value", "\"rawtypes\"")
+                                       .build())
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .superclass(ParameterizedTypeName.get(ClassName.get(TypeAdapter.class), typeVariableName));
 
@@ -638,6 +638,7 @@ public class TypeAdapterGenerator extends AdapterGenerator {
     }
 
     private static class FieldInfo {
+
         @NotNull
         private final TypeMirror type;
         @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -68,7 +68,6 @@ public class AnnotatedClass {
     @NotNull private final TypeMirror mType;
     @NotNull private final TypeElement mElement;
     @NotNull private final LinkedHashMap<FieldAccessor, TypeMirror> mMemberVariables;
-    @NotNull private final SupportedTypesModel mSupportedTypesModel;
     @NotNull private final Notation mNamingNotation;
 
     AnnotatedClass(@NotNull SupportedTypesModel supportedTypesModel,
@@ -82,7 +81,6 @@ public class AnnotatedClass {
                    @NotNull Notation namingNotation,
                    @Nullable FieldOption childFieldOption) {
         mNamingNotation = namingNotation;
-        mSupportedTypesModel = supportedTypesModel;
         mType = element.asType();
         mElement = element;
         Map<String, FieldAccessor> variableNames = new HashMap<>(element.getEnclosedElements().size());
@@ -105,7 +103,7 @@ public class AnnotatedClass {
         if (inheritedType != null) {
             DebugLog.log(TAG, "\t\tInherited Type - " + inheritedType.toString());
 
-            AnnotatedClass genericInheritedType = mSupportedTypesModel.addToKnownInheritedType(inheritedType, fieldOption);
+            AnnotatedClass genericInheritedType = supportedTypesModel.addToKnownInheritedType(inheritedType, fieldOption);
 
             LinkedHashMap<FieldAccessor, TypeMirror> inheritedMemberVariables = TypeUtils.getConcreteMembers(inheritedType,
                                                                                                              genericInheritedType.getElement(),

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/AnnotatedClass.java
@@ -127,7 +127,7 @@ public class AnnotatedClass {
     private void addMemberVariable(@NotNull FieldAccessor element, @NotNull TypeMirror typeMirror,
                                    @NotNull Map<String, FieldAccessor> variableNames) {
         FieldAccessor previousElement = variableNames.put(element.createGetterCode(), element);
-        if (null != previousElement) {
+        if (previousElement != null) {
             mMemberVariables.remove(previousElement);
             MessagerUtils.logInfo("Ignoring inherited Member variable with the same variable name in class" +
                                   element.toString() + ", with variable name " + previousElement.asType().toString());

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/ClassInfo.java
@@ -96,16 +96,6 @@ public final class ClassInfo {
     }
 
     /**
-     * return the class name as will be returned by Class.name() on runtime
-     *
-     * @return a valid class and package name.
-     */
-    @NotNull
-    public String getQualifiedClassName() {
-        return FileGenUtils.escapeStringForCodeBlock(mPackageName + "." + mClassName);
-    }
-
-    /**
      * The TypeMirror object backing this
      * ClassInfo object.
      *

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -114,11 +114,8 @@ public final class SupportedTypesModel {
      *
      * @param type the type that maps to a specific
      *             AnnotatedClass.
-     * @return the AnnotatedClass object associated
-     * with the class type.
      */
-    @NotNull
-    public AnnotatedClass addSupportedType(@NotNull TypeMirror type) {
+    public void addSupportedType(@NotNull TypeMirror type) {
         String outerClassType = TypeUtils.getOuterClassType(type);
         AnnotatedClass model = getSupportedType(outerClassType);
 
@@ -129,7 +126,6 @@ public final class SupportedTypesModel {
             }
             addSupportedType(model);
         }
-        return model;
     }
 
     /**

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -98,9 +98,9 @@ public final class SupportedTypesModel {
     public AnnotatedClass addToKnownInheritedType(@NotNull TypeMirror type, @Nullable FieldOption childFieldOption) {
         String outerClassType = TypeUtils.getOuterClassType(type);
         AnnotatedClass model = getSupportedType(outerClassType);
-        if (null == model) {
+        if (model == null) {
             model = mKnownInheritedTypesMap.get(outerClassType);
-            if (null == model) {
+            if (model == null) {
                 model = new AnnotatedClass(this, TypeUtils.safeTypeMirrorToTypeElement(type), mNamingNotation, childFieldOption);
                 mKnownInheritedTypesMap.put(outerClassType, model);
             }
@@ -121,7 +121,7 @@ public final class SupportedTypesModel {
 
         if (model == null) {
             model = mKnownInheritedTypesMap.get(outerClassType);
-            if (null == model) {
+            if (model == null) {
                 model = new AnnotatedClass(this, TypeUtils.safeTypeMirrorToTypeElement(type), mNamingNotation);
             }
             addSupportedType(model);

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/SupportedTypesModel.java
@@ -40,11 +40,9 @@ public final class SupportedTypesModel {
 
     @NotNull private final Map<String, AnnotatedClass> mSupportedTypesMap = new HashMap<>();
     @NotNull private final Map<String, AnnotatedClass> mKnownInheritedTypesMap = new HashMap<>();
-    @NotNull private final String mGeneratedStagFactoryName;
     @NotNull private final Notation mNamingNotation;
 
-    public SupportedTypesModel(@NotNull String generatedStagFactoryName, @NotNull Notation namingNotation) {
-        mGeneratedStagFactoryName = generatedStagFactoryName;
+    public SupportedTypesModel(@NotNull Notation namingNotation) {
         mNamingNotation = namingNotation;
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/accessor/FieldAccessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/model/accessor/FieldAccessor.java
@@ -157,11 +157,11 @@ public abstract class FieldAccessor {
     @NotNull
     public final String getJsonName() {
 
-        String name = null != mVariableElement.getAnnotation(SerializedName.class) ?
-                mVariableElement.getAnnotation(SerializedName.class).value() :
-                null;
+        String name = mVariableElement.getAnnotation(SerializedName.class) != null
+                ? mVariableElement.getAnnotation(SerializedName.class).value()
+                : null;
 
-        if (null == name || name.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             name = mVariableElement.getSimpleName().toString();
         }
         return name;
@@ -174,9 +174,9 @@ public abstract class FieldAccessor {
      */
     @Nullable
     public final String[] getAlternateJsonNames() {
-        return null != mVariableElement.getAnnotation(SerializedName.class) ?
-                mVariableElement.getAnnotation(SerializedName.class).alternate() :
-                null;
+        return mVariableElement.getAnnotation(SerializedName.class) != null
+                ? mVariableElement.getAnnotation(SerializedName.class).alternate()
+                : null;
     }
 
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -60,7 +60,7 @@ public final class ElementUtils {
     @Nullable
     public static TypeMirror getTypeFromQualifiedName(@NotNull String qualifiedName) {
         TypeElement typeElement = getTypeElementFromQualifiedName(qualifiedName);
-        return null != typeElement ? typeElement.asType() : null;
+        return typeElement != null ? typeElement.asType() : null;
     }
 
     @Nullable

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -90,8 +90,8 @@ public final class ElementUtils {
      * @param <T>             annotation type
      * @return {@code true} if the element is annotated, {@code false} otherwise
      */
-    public static <T extends Annotation> boolean isAnnotatedWith(@NotNull Class<T> annotationClass,
-                                                                 @Nullable Element element) {
+    private static <T extends Annotation> boolean isAnnotatedWith(@NotNull Class<T> annotationClass,
+                                                                  @Nullable Element element) {
         return element != null && element.getAnnotation(annotationClass) != null;
     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/ElementUtils.java
@@ -108,7 +108,7 @@ public final class ElementUtils {
         }
         ElementKind elementKind = element.getKind();
         return (elementKind == ElementKind.CLASS || elementKind == ElementKind.ENUM)
-            && isAnnotatedWith(UseStag.class, element);
+               && isAnnotatedWith(UseStag.class, element);
     }
 
     @Nullable

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/FileGenUtils.java
@@ -43,7 +43,7 @@ import javax.tools.StandardLocation;
 
 public final class FileGenUtils {
 
-    public static final String CODE_BLOCK_ESCAPED_SEPARATOR = "$$";
+    private static final String CODE_BLOCK_ESCAPED_SEPARATOR = "$$";
     private static final String UNESCAPED_SEPARATOR = "$";
 
     private FileGenUtils() {

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/KnownTypeAdapterFactoriesUtils.java
@@ -92,7 +92,7 @@ public final class KnownTypeAdapterFactoriesUtils {
         String[] knownFactories = content.toString().split("[\\n\\r]+");
         for (String knownFactory : knownFactories) {
             TypeElement element = elementUtils.getTypeElement(knownFactory);
-            if (null != element) {
+            if (element != null) {
                 resultSet.add(element.asType());
             }
         }
@@ -113,7 +113,7 @@ public final class KnownTypeAdapterFactoriesUtils {
                 String line;
                 while ((line = bufferedReader.readLine()) != null) {
                     TypeElement element = elementUtils.getTypeElement(line.trim());
-                    if (null != element) {
+                    if (element != null) {
                         resultSet.add(element.asType());
                     }
 

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -120,26 +120,6 @@ public final class TypeUtils {
     }
 
     /**
-     * Retrieves the outer type of a parameterized class.
-     * e.g. an ArrayList{@literal <T>} would be returned as
-     * just ArrayList. If an interface is passed in, i.e. a
-     * List, the underlying implementation will be returned,
-     * i.e. ArrayList.
-     *
-     * @param type the type to get the outer class from/
-     * @return the outer class of the type passed in, or the
-     * type itself if it is not parameterized.
-     */
-    @NotNull
-    public static String getSimpleOuterClassType(@NotNull TypeMirror type) {
-        if (type instanceof DeclaredType) {
-            return ((DeclaredType) type).asElement().getSimpleName().toString();
-        } else {
-            return type.toString();
-        }
-    }
-
-    /**
      * Determines whether or not the type has type parameters.
      *
      * @param type the type to check.
@@ -467,16 +447,6 @@ public final class TypeUtils {
     }
 
     /**
-     * Method to check if the {@link TypeMirror} is of primitive type
-     *
-     * @param type :TypeMirror type
-     * @return String
-     */
-    public static String getObjectForPrimitive(@NotNull String type) {
-        return PRIMITIVE_TO_OBJECT_MAP.get(type);
-    }
-
-    /**
      * Method to check if the {@link TypeMirror} is of {@link ArrayType}
      *
      * @param type :TypeMirror type
@@ -510,20 +480,6 @@ public final class TypeUtils {
         return outerClassType.equals(ArrayList.class.getName()) ||
                outerClassType.equals(List.class.getName()) ||
                outerClassType.equals(Collection.class.getName());
-    }
-
-    /**
-     * Method to check if the {@link TypeMirror} is of {@link Object}
-     *
-     * @param type :TypeMirror type
-     * @return boolean
-     */
-    public static boolean isNativeObject(@Nullable TypeMirror type) {
-        if (type == null) {
-            return false;
-        }
-        String outerClassType = TypeUtils.getOuterClassType(type);
-        return outerClassType.equals(Object.class.getName());
     }
 
     /**
@@ -649,16 +605,11 @@ public final class TypeUtils {
         }
     }
 
-    public static boolean isAssignable(TypeMirror t1, TypeMirror t2) {
-        return getUtils().isAssignable(t1, t2);
-    }
-
     @NotNull
-    public static DeclaredType getDeclaredTypeForParameterizedClass(@NotNull String className) {
-        Types types = getUtils();
-        WildcardType wildcardType = types.getWildcardType(null, null);
-        TypeMirror[] typex = {wildcardType};
-        return types.getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(className), typex);
+    private static DeclaredType getDeclaredTypeForParameterizedClass(@NotNull String className) {
+        WildcardType wildcardType = getUtils().getWildcardType(null, null);
+        TypeMirror[] types = {wildcardType};
+        return getUtils().getDeclaredType(ElementUtils.getTypeElementFromQualifiedName(className), types);
     }
 
 
@@ -668,7 +619,4 @@ public final class TypeUtils {
         return types.getDeclaredType(typeElem, typeArgs);
     }
 
-    public static boolean isWildcardType(@Nullable TypeMirror typeMirror) {
-        return typeMirror instanceof WildcardType;
-    }
 }

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -59,7 +59,6 @@ public final class TypeUtils {
 
     @Nullable private static Types sTypeUtils;
 
-
     static {
         PRIMITIVE_TO_OBJECT_MAP.put(boolean.class.getName(), Boolean.class.getName());
         PRIMITIVE_TO_OBJECT_MAP.put(int.class.getName(), Integer.class.getName());
@@ -383,7 +382,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), resolvedType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Parameterized Type - " + member.getValue().toString() +
-                        " resolved to - " + resolvedType.toString());
+                                      " resolved to - " + resolvedType.toString());
                 } else {
 
                     int index = inheritedTypes.indexOf(member.getKey().asType());
@@ -391,7 +390,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), concreteType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Type - " + member.getValue().toString() +
-                        " resolved to - " + concreteType.toString());
+                                      " resolved to - " + concreteType.toString());
                 }
             }
         }
@@ -443,7 +442,7 @@ public final class TypeUtils {
             concreteGenericTypes.add(resolveTypeVars(type, inheritedTypes, concreteTypes));
         }
         TypeMirror[] concreteTypeArray =
-            concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
+                concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
         return types.getDeclaredType(typeElement, concreteTypeArray);
     }
 
@@ -509,8 +508,8 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(ArrayList.class.getName()) ||
-            outerClassType.equals(List.class.getName()) ||
-            outerClassType.equals(Collection.class.getName());
+               outerClassType.equals(List.class.getName()) ||
+               outerClassType.equals(Collection.class.getName());
     }
 
     /**
@@ -539,11 +538,11 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(Map.class.getName()) ||
-            outerClassType.equals(HashMap.class.getName()) ||
-            outerClassType.equals(ConcurrentHashMap.class.getName()) ||
-            outerClassType.equals("android.util.ArrayMap") ||
-            outerClassType.equals("android.support.v4.util.ArrayMap") ||
-            outerClassType.equals(LinkedHashMap.class.getName());
+               outerClassType.equals(HashMap.class.getName()) ||
+               outerClassType.equals(ConcurrentHashMap.class.getName()) ||
+               outerClassType.equals("android.util.ArrayMap") ||
+               outerClassType.equals("android.support.v4.util.ArrayMap") ||
+               outerClassType.equals(LinkedHashMap.class.getName());
     }
 
     /**
@@ -554,9 +553,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedNative(@NotNull String type) {
         return isSupportedPrimitive(type) || type.equals(String.class.getName()) ||
-            type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
-            type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
-            type.equals(Float.class.getName()) || type.equals(Number.class.getName());
+               type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
+               type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
+               type.equals(Float.class.getName()) || type.equals(Number.class.getName());
     }
 
     /**
@@ -565,7 +564,7 @@ public final class TypeUtils {
     @NotNull
     public static TypeMirror getArrayInnerType(@NotNull TypeMirror type) {
         return (type instanceof ArrayType) ? ((ArrayType) type).getComponentType() : ((DeclaredType) type).getTypeArguments()
-            .get(0);
+                .get(0);
     }
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -383,7 +383,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), resolvedType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Parameterized Type - " + member.getValue().toString() +
-                        " resolved to - " + resolvedType.toString());
+                                      " resolved to - " + resolvedType.toString());
                 } else {
 
                     int index = inheritedTypes.indexOf(member.getKey().asType());
@@ -391,7 +391,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), concreteType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Type - " + member.getValue().toString() +
-                        " resolved to - " + concreteType.toString());
+                                      " resolved to - " + concreteType.toString());
                 }
             }
         }
@@ -443,7 +443,7 @@ public final class TypeUtils {
             concreteGenericTypes.add(resolveTypeVars(type, inheritedTypes, concreteTypes));
         }
         TypeMirror[] concreteTypeArray =
-            concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
+                concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
         return types.getDeclaredType(typeElement, concreteTypeArray);
     }
 
@@ -509,8 +509,8 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(ArrayList.class.getName()) ||
-            outerClassType.equals(List.class.getName()) ||
-            outerClassType.equals(Collection.class.getName());
+               outerClassType.equals(List.class.getName()) ||
+               outerClassType.equals(Collection.class.getName());
     }
 
     /**
@@ -539,11 +539,11 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(Map.class.getName()) ||
-            outerClassType.equals(HashMap.class.getName()) ||
-            outerClassType.equals(ConcurrentHashMap.class.getName()) ||
-            outerClassType.equals("android.util.ArrayMap") ||
-            outerClassType.equals("android.support.v4.util.ArrayMap") ||
-            outerClassType.equals(LinkedHashMap.class.getName());
+               outerClassType.equals(HashMap.class.getName()) ||
+               outerClassType.equals(ConcurrentHashMap.class.getName()) ||
+               outerClassType.equals("android.util.ArrayMap") ||
+               outerClassType.equals("android.support.v4.util.ArrayMap") ||
+               outerClassType.equals(LinkedHashMap.class.getName());
     }
 
     /**
@@ -554,9 +554,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedNative(@NotNull String type) {
         return isSupportedPrimitive(type) || type.equals(String.class.getName()) ||
-            type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
-            type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
-            type.equals(Float.class.getName()) || type.equals(Number.class.getName());
+               type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
+               type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
+               type.equals(Float.class.getName()) || type.equals(Number.class.getName());
     }
 
     /**
@@ -565,7 +565,7 @@ public final class TypeUtils {
     @NotNull
     public static TypeMirror getArrayInnerType(@NotNull TypeMirror type) {
         return (type instanceof ArrayType) ? ((ArrayType) type).getComponentType() : ((DeclaredType) type).getTypeArguments()
-            .get(0);
+                .get(0);
     }
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -383,7 +383,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), resolvedType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Parameterized Type - " + member.getValue().toString() +
-                                      " resolved to - " + resolvedType.toString());
+                        " resolved to - " + resolvedType.toString());
                 } else {
 
                     int index = inheritedTypes.indexOf(member.getKey().asType());
@@ -391,7 +391,7 @@ public final class TypeUtils {
                     map.put(member.getKey(), concreteType);
 
                     DebugLog.log(TAG, "\t\t\tGeneric Type - " + member.getValue().toString() +
-                                      " resolved to - " + concreteType.toString());
+                        " resolved to - " + concreteType.toString());
                 }
             }
         }
@@ -443,7 +443,7 @@ public final class TypeUtils {
             concreteGenericTypes.add(resolveTypeVars(type, inheritedTypes, concreteTypes));
         }
         TypeMirror[] concreteTypeArray =
-                concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
+            concreteGenericTypes.toArray(new TypeMirror[concreteGenericTypes.size()]);
         return types.getDeclaredType(typeElement, concreteTypeArray);
     }
 
@@ -509,8 +509,8 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(ArrayList.class.getName()) ||
-               outerClassType.equals(List.class.getName()) ||
-               outerClassType.equals(Collection.class.getName());
+            outerClassType.equals(List.class.getName()) ||
+            outerClassType.equals(Collection.class.getName());
     }
 
     /**
@@ -539,11 +539,11 @@ public final class TypeUtils {
         }
         String outerClassType = TypeUtils.getOuterClassType(type);
         return outerClassType.equals(Map.class.getName()) ||
-               outerClassType.equals(HashMap.class.getName()) ||
-               outerClassType.equals(ConcurrentHashMap.class.getName()) ||
-               outerClassType.equals("android.util.ArrayMap") ||
-               outerClassType.equals("android.support.v4.util.ArrayMap") ||
-               outerClassType.equals(LinkedHashMap.class.getName());
+            outerClassType.equals(HashMap.class.getName()) ||
+            outerClassType.equals(ConcurrentHashMap.class.getName()) ||
+            outerClassType.equals("android.util.ArrayMap") ||
+            outerClassType.equals("android.support.v4.util.ArrayMap") ||
+            outerClassType.equals(LinkedHashMap.class.getName());
     }
 
     /**
@@ -554,9 +554,9 @@ public final class TypeUtils {
      */
     public static boolean isSupportedNative(@NotNull String type) {
         return isSupportedPrimitive(type) || type.equals(String.class.getName()) ||
-               type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
-               type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
-               type.equals(Float.class.getName()) || type.equals(Number.class.getName());
+            type.equals(Long.class.getName()) || type.equals(Integer.class.getName()) ||
+            type.equals(Boolean.class.getName()) || type.equals(Double.class.getName()) ||
+            type.equals(Float.class.getName()) || type.equals(Number.class.getName());
     }
 
     /**
@@ -565,7 +565,7 @@ public final class TypeUtils {
     @NotNull
     public static TypeMirror getArrayInnerType(@NotNull TypeMirror type) {
         return (type instanceof ArrayType) ? ((ArrayType) type).getComponentType() : ((DeclaredType) type).getTypeArguments()
-                .get(0);
+            .get(0);
     }
 
     @NotNull

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/utils/TypeUtils.java
@@ -128,7 +128,7 @@ public final class TypeUtils {
      */
     public static boolean isParameterizedType(@Nullable TypeMirror type) {
         List<? extends TypeMirror> typeArguments = getTypeArguments(type);
-        return null != typeArguments && !typeArguments.isEmpty();
+        return typeArguments != null && !typeArguments.isEmpty();
     }
 
     /**

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/ElementUtilsUnitTest.kt
@@ -33,7 +33,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
-import java.util.*
+import java.util.ArrayList
 
 class ElementUtilsUnitTest : BaseUnitTest() {
 

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.vimeo.sample_java_model.NullFields
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.StringWriter
+import com.vimeo.sample_java_model.stag.generated.Stag
 
 /**
  * Integration tests for the compiler.

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/StagProcessorIntegrationTest.kt
@@ -4,7 +4,6 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonWriter
 import com.vimeo.sample_java_model.NullFields
-import com.vimeo.sample_java_model.stag.generated.Stag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.StringWriter

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/TypeUtilsUnitTest.kt
@@ -86,7 +86,7 @@ class TypeUtilsUnitTest : BaseUnitTest() {
         val genericMembers = HashMap<FieldAccessor, TypeMirror>()
         genericElement.enclosedElements
                 .filterIsInstance<VariableElement>()
-                .forEach { genericMembers.put(DirectFieldAccessor(it), it.asType()) }
+                .forEach { genericMembers[DirectFieldAccessor(it)] = it.asType() }
 
         val concreteType = TypeUtils.getInheritedType(Utils.getElementFromClass(DummyInheritedClass::class.java))
 

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyClassWithConstructor.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyClassWithConstructor.kt
@@ -12,5 +12,5 @@ class DummyClassWithConstructor {
         this.string = string
     }
 
-    constructor() {}
+    constructor()
 }

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyGenericClass.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyGenericClass.kt
@@ -24,7 +24,9 @@
 package com.vimeo.stag.processor.dummy
 
 import com.vimeo.stag.processor.TypeUtilsUnitTest
-import java.util.*
+import java.util.ArrayList
+import java.util.HashMap
+import java.util.HashSet
 
 /**
  * Do not change this class without sure the

--- a/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyMapClass.kt
+++ b/stag-library-compiler/src/test/java/com/vimeo/stag/processor/dummy/DummyMapClass.kt
@@ -45,10 +45,10 @@ class DummyMapClass : MutableMap<Any, Any> {
 
     override fun clear() {}
 
-    override fun put(key: Any, value: Any) = null
+    override fun put(key: Any, value: Any): Nothing? = null
 
     override fun putAll(from: Map<out Any, Any>) {}
 
-    override fun remove(key: Any) = null
+    override fun remove(key: Any): Nothing? = null
 
 }

--- a/stag-library/build.gradle
+++ b/stag-library/build.gradle
@@ -63,7 +63,7 @@ def pomConfig = {
             organisationUrl "https://github.com/vimeo"
         }
     }
-    
+
     scm {
         connection "scm:git:git://github.com/vimeo/stag-java.git"
         developerConnection "scm:git:ssh://github.com:vimeo/stag-java.git"
@@ -123,10 +123,12 @@ allprojects {
                             passphrase = System.getenv('BINTRAY_GPG_PASSWORD')
                         }
                         mavenCentralSync {
-                            sync = true //Optional (true by default). Determines whether to sync the version to Maven Central.
+                            sync = true
+                            //Optional (true by default). Determines whether to sync the version to Maven Central.
                             user = System.getenv('SONATYPE_TOKEN_USER') //OSS user token
                             password = System.getenv('SONATYPE_TOKEN_PASSWORD') //OSS user password
-                            close = '1' //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+                            close = '1'
+                            //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
                         }
                     }
                 }

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -989,6 +989,7 @@ public final class KnownTypeAdapters {
      * Type Adapter for {@link Object}
      */
     public static final class ObjectTypeAdapter extends TypeAdapter<Object> {
+
         public final TypeToken<Object> TYPE_TOKEN = TypeToken.get(Object.class);
 
         private final Gson gson;

--- a/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
+++ b/stag-library/src/main/java/com/vimeo/stag/KnownTypeAdapters.java
@@ -494,7 +494,7 @@ public final class KnownTypeAdapters {
         public static int[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Integer> arrayList = INTEGER_ARRAY_LIST_ADAPTER.read(reader);
             int[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new int[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -529,7 +529,7 @@ public final class KnownTypeAdapters {
         public static long[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Long> arrayList = LONG_ARRAY_LIST_ADAPTER.read(reader);
             long[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new long[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -564,7 +564,7 @@ public final class KnownTypeAdapters {
         public static double[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Double> arrayList = DOUBLE_ARRAY_LIST_ADAPTER.read(reader);
             double[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new double[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -599,7 +599,7 @@ public final class KnownTypeAdapters {
         public static short[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Short> arrayList = SHORT_ARRAY_LIST_ADAPTER.read(reader);
             short[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new short[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -634,7 +634,7 @@ public final class KnownTypeAdapters {
         public static float[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Float> arrayList = FLOAT_ARRAY_LIST_ADAPTER.read(reader);
             float[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new float[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -669,7 +669,7 @@ public final class KnownTypeAdapters {
         public static boolean[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Boolean> arrayList = BOOLEAN_ARRAY_LIST_ADAPTER.read(reader);
             boolean[] result = null;
-            if (null != arrayList) {
+            if (arrayList != null) {
                 result = new boolean[arrayList.size()];
                 for (int idx = 0; idx < arrayList.size(); idx++) {
                     result[idx] = arrayList.get(idx);
@@ -704,7 +704,7 @@ public final class KnownTypeAdapters {
         public static byte[] read(@NotNull JsonReader reader) throws IOException {
             ArrayList<Byte> byteArrayList = BYTE_ARRAY_LIST_ADAPTER.read(reader);
             byte[] result = null;
-            if (null != byteArrayList) {
+            if (byteArrayList != null) {
                 result = new byte[byteArrayList.size()];
                 for (int idx = 0; idx < byteArrayList.size(); idx++) {
                     result[idx] = byteArrayList.get(idx);
@@ -737,7 +737,7 @@ public final class KnownTypeAdapters {
         @Nullable
         public static char[] read(@NotNull JsonReader reader) throws IOException {
             String string = STRING_NULL_SAFE_TYPE_ADAPTER.read(reader);
-            return null != string ? string.toCharArray() : null;
+            return string != null ? string.toCharArray() : null;
         }
     }
 

--- a/stag-library/src/main/java/com/vimeo/stag/Types.java
+++ b/stag-library/src/main/java/com/vimeo/stag/Types.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 
 public class Types {
+
     public static WildcardType getWildcardType(Type[] upperBounds, Type[] lowerBounds) {
         return new WildcardTypeImpl(upperBounds, lowerBounds);
     }

--- a/stag-library/src/main/java/com/vimeo/stag/Types.java
+++ b/stag-library/src/main/java/com/vimeo/stag/Types.java
@@ -4,7 +4,9 @@ package com.vimeo.stag;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 
-public class Types {
+public final class Types {
+
+    private Types() {}
 
     public static WildcardType getWildcardType(Type[] upperBounds, Type[] lowerBounds) {
         return new WildcardTypeImpl(upperBounds, lowerBounds);
@@ -12,7 +14,8 @@ public class Types {
 
     private static final class WildcardTypeImpl implements WildcardType {
 
-        private Type[] upperBounds, lowerBounds;
+        private final Type[] upperBounds;
+        private final Type[] lowerBounds;
 
         public WildcardTypeImpl(Type[] upperBounds, Type[] lowerBounds) {
             this.upperBounds = upperBounds;

--- a/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
+++ b/stag-library/src/test/java/com/vimeo/stag/KnownTypeAdaptersTest.java
@@ -552,7 +552,7 @@ public class KnownTypeAdaptersTest {
         ArrayList<String> dummyList = Utils.createStringDummyList();
 
         TypeAdapter<ArrayList<String>> listTypeAdapter = new KnownTypeAdapters.ListTypeAdapter<>(TypeAdapters.STRING,
-                new KnownTypeAdapters.ArrayListInstantiator<String>());
+                                                                                                 new KnownTypeAdapters.ArrayListInstantiator<String>());
 
         StringWriter stringWriter = new StringWriter();
         listTypeAdapter.write(new JsonWriter(stringWriter), dummyList);
@@ -569,7 +569,7 @@ public class KnownTypeAdaptersTest {
         ArrayList<Integer> intDummyList = Utils.createIntegerDummyList();
 
         TypeAdapter<ArrayList<Integer>> listTypeAdapter1 = new KnownTypeAdapters.ListTypeAdapter<>(KnownTypeAdapters.INTEGER,
-                new KnownTypeAdapters.ArrayListInstantiator<Integer>());
+                                                                                                   new KnownTypeAdapters.ArrayListInstantiator<Integer>());
         stringWriter = new StringWriter();
         listTypeAdapter1.write(new JsonWriter(stringWriter), intDummyList);
         jsonString = stringWriter.toString();
@@ -594,7 +594,7 @@ public class KnownTypeAdaptersTest {
         HashMap<String, String> dummyMap = Utils.createStringDummyMap();
 
         TypeAdapter<HashMap<String, String>> mapTypeAdapter = new KnownTypeAdapters.MapTypeAdapter<>(TypeAdapters.STRING, TypeAdapters.STRING,
-                new KnownTypeAdapters.HashMapInstantiator<String, String>());
+                                                                                                     new KnownTypeAdapters.HashMapInstantiator<String, String>());
 
         StringWriter stringWriter = new StringWriter();
         mapTypeAdapter.write(new JsonWriter(stringWriter), dummyMap);
@@ -609,7 +609,7 @@ public class KnownTypeAdaptersTest {
         HashMap<Integer, Integer> intDummyMap = Utils.createIntegerDummyMap();
 
         TypeAdapter<HashMap<Integer, Integer>> mapTypeAdapter1 = new KnownTypeAdapters.MapTypeAdapter<>(KnownTypeAdapters.INTEGER, KnownTypeAdapters.INTEGER,
-                new KnownTypeAdapters.HashMapInstantiator<Integer, Integer>());
+                                                                                                        new KnownTypeAdapters.HashMapInstantiator<Integer, Integer>());
         stringWriter = new StringWriter();
         mapTypeAdapter1.write(new JsonWriter(stringWriter), intDummyMap);
         jsonString = stringWriter.toString();

--- a/stag-library/src/test/java/com/vimeo/stag/Utils.java
+++ b/stag-library/src/test/java/com/vimeo/stag/Utils.java
@@ -10,7 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-public class Utils {
+public final class Utils {
+
+    private Utils() {}
 
     public static <K, V> void assertMapsEqual(Map<K, V> map1, Map<K, V> map2) throws Exception {
         for (Entry<K, V> kvEntry : map1.entrySet()) {


### PR DESCRIPTION
## Summary
- Cleaned up lint warnings
- Cleaned up formatting issues
- Updated kotlin version to 1.2.21
- Updated AssertJ dependency
- Updated JavaPoet dependency
- Fixed formatting of generated code
- Changed indentation of generated code to 4 spaces
- Fixed variable names
- Removed unused code
- changed null check order to `item == null` instead of `null == item` for consistency
- Improved readability of TypeAdapterGenerator code
- Created `SwitchCodeBlockBuilder` to aid in improving readability of switch creation code