### PR TITLE
Add kotlin to initialization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,28 @@ gradle.projectsEvaluated {
 }
 ```
 
-### Android Gradle
+### Kotlin Gradle
+```groovy
+apply plugin: 'kotlin-kapt'
+
+dependencies {
+    def stagVersion = '2.5.1'
+    compile "com.vimeo.stag:stag-library:$stagVersion"
+    kapt "com.vimeo.stag:stag-library-compiler:$stagVersion"
+}
+
+kapt {
+    correctErrorTypes = true
+    // Optional annotation processor arguments (see below)
+    arguments {
+        arg("stagDebug", "true")
+        arg("stagGeneratedPackageName", "com.vimeo.sample.stag.generated")
+        arg("stagAssumeHungarianNotation", "true")
+    }
+}
+```
+
+### Android Gradle (Java)
 
 ```groovy
 dependencies {


### PR DESCRIPTION
#### Summary
Add kotlin to initialization section. It was previously unclear how to use the library in a Kotlin project. Adding the gradle setup should clear things up.