### PR TITLE
[BUG] Switching nullability library to avoid dependency collision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.2.50'
+        kotlinVersion = '1.2.61'
         jacocoVersion = '0.7.9' // See http://www.eclemma.org/jacoco/
         gsonVersion = '2.8.2'
         assertJ = '3.9.1'

--- a/integration-test-android/build.gradle
+++ b/integration-test-android/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:support-annotations:27.1.1'
 

--- a/integration-test-android/build.gradle
+++ b/integration-test-android/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.intellij:annotations:12.0@jar'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:support-annotations:27.1.1'
 

--- a/integration-test-java-cross-module/build.gradle
+++ b/integration-test-java-cross-module/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "net.ltgt.apt"
 
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
     implementation 'com.android.support:support-annotations:27.1.1'
 
     implementation project(':stag-library')

--- a/integration-test-java-cross-module/build.gradle
+++ b/integration-test-java-cross-module/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "net.ltgt.apt"
 
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'com.intellij:annotations:12.0@jar'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
     implementation 'com.android.support:support-annotations:27.1.1'
 
     implementation project(':stag-library')

--- a/integration-test-java/build.gradle
+++ b/integration-test-java/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: "net.ltgt.apt"
 
 dependencies {
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
     implementation "com.google.code.gson:gson:$gsonVersion"
 
     implementation project(':stag-library')

--- a/integration-test-java/build.gradle
+++ b/integration-test-java/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: "net.ltgt.apt"
 
 dependencies {
-    implementation 'com.intellij:annotations:12.0@jar'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
     implementation "com.google.code.gson:gson:$gsonVersion"
 
     implementation project(':stag-library')

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation 'com.squareup:javapoet:1.11.1'
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
     implementation 'com.google.auto.service:auto-service:1.0-rc3'
 
     // Used by both auto-service and compile-testing, we need to resolve the version for them.

--- a/stag-library-compiler/build.gradle
+++ b/stag-library-compiler/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     implementation project(':stag-library')
 
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'com.squareup:javapoet:1.10.0'
-    implementation 'com.intellij:annotations:12.0@jar'
+    implementation 'com.squareup:javapoet:1.11.1'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
     implementation 'com.google.auto.service:auto-service:1.0-rc3'
 
     // Used by both auto-service and compile-testing, we need to resolve the version for them.
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
-    testImplementation 'org.mockito:mockito-core:2.18.0'
+    testImplementation 'org.mockito:mockito-core:2.19.1'
     testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0", { exclude group: 'org.jetbrains.kotlin' }
 }
 

--- a/stag-library/build.gradle
+++ b/stag-library/build.gradle
@@ -24,7 +24,7 @@ jacocoTestReport.dependsOn test
 
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'com.intellij:annotations:12.0@jar'
+    implementation 'org.jetbrains:annotations:16.0.2@jar'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.assertj:assertj-core:$assertJ"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"

--- a/stag-library/build.gradle
+++ b/stag-library/build.gradle
@@ -24,7 +24,7 @@ jacocoTestReport.dependsOn test
 
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation 'org.jetbrains:annotations:16.0.2@jar'
+    implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.assertj:assertj-core:$assertJ"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"


### PR DESCRIPTION
# Issue
- https://github.com/vimeo/stag-java/issues/179

#### Summary
Collisions are caused with libraries that utilize the `org.jetbrains.annotations` package, or other libraries that do, due to stag using a really old version of the annotation library. The library switched to a different namespace, and the collision occurred because of that. Switching from using `com.intellij:annotations:12.0@jar` to `org.jetbrains:annotations-java5:16.0.2@jar` fixes the problem. Note, that due to compiling against java7, we currently need to use the `-java5` version of the library.

#### How to Test
- Run the tests.