### PR TITLE
Support of serialize-null while building stag

### DIFF
--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/ReadSpecGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/ReadSpecGenerator.java
@@ -1,0 +1,110 @@
+package com.vimeo.stag.processor.generators.typeadapter;
+
+import com.google.gson.stream.JsonReader;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.vimeo.stag.processor.generators.TypeAdapterGenerator;
+import com.vimeo.stag.processor.generators.model.accessor.FieldAccessor;
+import com.vimeo.stag.processor.utils.TypeUtils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.TypeMirror;
+
+public class ReadSpecGenerator {
+    @NotNull
+    public static MethodSpec getReadMethodSpec(@NotNull TypeName typeName,
+                                               @NotNull Map<FieldAccessor, TypeMirror> elements,
+                                               @NotNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo) {
+        MethodSpec.Builder builder = MethodSpec.methodBuilder("read")
+                .addParameter(JsonReader.class, "reader")
+                .returns(typeName)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .addException(IOException.class);
+
+        builder.addStatement("com.google.gson.stream.JsonToken peek = reader.peek()");
+
+        builder.beginControlFlow("if (com.google.gson.stream.JsonToken.NULL == peek)");
+        builder.addStatement("reader.nextNull()");
+        builder.addStatement("return null");
+        builder.endControlFlow();
+
+
+        builder.beginControlFlow("if (com.google.gson.stream.JsonToken.BEGIN_OBJECT != peek)");
+        builder.addStatement("reader.skipValue()");
+        builder.addStatement("return null");
+        builder.endControlFlow();
+
+        builder.addStatement("reader.beginObject()");
+        builder.addStatement(typeName + " object = new " + typeName + "()");
+
+        builder.beginControlFlow("while (reader.hasNext())");
+        builder.addStatement("String name = reader.nextName()");
+        builder.beginControlFlow("switch (name)");
+
+
+        final List<FieldAccessor> nonNullFields = new ArrayList<>();
+
+        for (Map.Entry<FieldAccessor, TypeMirror> element : elements.entrySet()) {
+            final FieldAccessor fieldAccessor = element.getKey();
+            String name = fieldAccessor.getJsonName();
+
+            final TypeMirror elementValue = element.getValue();
+
+            builder.addCode("case \"" + name + "\":\n");
+
+            String[] alternateJsonNames = fieldAccessor.getAlternateJsonNames();
+            if (alternateJsonNames != null && alternateJsonNames.length > 0) {
+                for (String alternateJsonName : alternateJsonNames) {
+                    builder.addCode("case \"" + alternateJsonName + "\":\n");
+                }
+            }
+
+            String variableType = element.getValue().toString();
+            boolean isPrimitive = TypeUtils.isSupportedPrimitive(variableType);
+
+            if (isPrimitive) {
+                builder.addStatement("\tobject." +
+                        fieldAccessor.createSetterCode(adapterFieldInfo.getAdapterAccessor(elementValue, name) +
+                                ".read(reader, object." + fieldAccessor.createGetterCode() + ")"));
+
+            } else {
+                builder.addStatement("\tobject." + fieldAccessor.createSetterCode(adapterFieldInfo.getAdapterAccessor(elementValue, name) +
+                        ".read(reader)"));
+            }
+
+
+            builder.addStatement("\tbreak");
+            if (fieldAccessor.doesRequireNotNull()) {
+                if (!TypeUtils.isSupportedPrimitive(elementValue.toString())) {
+                    nonNullFields.add(fieldAccessor);
+                }
+            }
+        }
+
+        builder.addCode("default:\n");
+        builder.addStatement("reader.skipValue()");
+        builder.addStatement("break");
+        builder.endControlFlow();
+        builder.endControlFlow();
+
+        builder.addStatement("reader.endObject()");
+
+        for (FieldAccessor nonNullField : nonNullFields) {
+            builder.beginControlFlow("if (object." + nonNullField.createGetterCode() + " == null)");
+            builder.addStatement("throw new java.io.IOException(\"" + nonNullField.createGetterCode() + " cannot be null\")");
+            builder.endControlFlow();
+        }
+
+        builder.addStatement("return object");
+
+        return builder.build();
+    }
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/WriteSpecGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/WriteSpecGenerator.java
@@ -1,0 +1,115 @@
+package com.vimeo.stag.processor.generators.typeadapter;
+
+import android.support.annotation.NonNull;
+
+import com.google.gson.stream.JsonWriter;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.vimeo.stag.processor.generators.TypeAdapterGenerator;
+import com.vimeo.stag.processor.generators.model.accessor.FieldAccessor;
+import com.vimeo.stag.processor.utils.TypeUtils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.TypeMirror;
+
+public class WriteSpecGenerator {
+
+    @NotNull
+    public static MethodSpec getWriteMethodSpec(@NonNull TypeName typeName, @NonNull Map<FieldAccessor, TypeMirror> memberVariables,
+                                                @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, boolean serializeNulls) {
+        final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("write")
+                .addParameter(JsonWriter.class, "writer")
+                .addParameter(typeName, "object")
+                .returns(void.class)
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .addException(IOException.class);
+
+        methodBuilder.beginControlFlow("if (object == null)");
+        methodBuilder.addStatement("writer.nullValue()");
+        methodBuilder.addStatement("return");
+        methodBuilder.endControlFlow();
+        methodBuilder.addStatement("writer.beginObject()");
+
+        for (Map.Entry<FieldAccessor, TypeMirror> element : memberVariables.entrySet()) {
+            FieldAccessor fieldAccessor = element.getKey();
+            final String getterCode = fieldAccessor.createGetterCode();
+
+            String name = fieldAccessor.getJsonName();
+            String variableType = element.getValue().toString();
+
+            boolean isPrimitive = TypeUtils.isSupportedPrimitive(variableType);
+            if (serializeNulls) {
+                specForSerializedNullsEnabled(methodBuilder, element, adapterFieldInfo, fieldAccessor, getterCode, name, isPrimitive);
+            } else {
+                specForSerializedNullsDisabled(methodBuilder, element, adapterFieldInfo, fieldAccessor, getterCode, name, isPrimitive);
+            }
+        }
+
+        methodBuilder.addCode("\n");
+        methodBuilder.addStatement("writer.endObject()");
+        return methodBuilder.build();
+    }
+
+    private static void specForSerializedNullsDisabled(@NonNull MethodSpec.Builder methodBuilder, @NonNull Map.Entry<FieldAccessor, TypeMirror> element,
+                                                       @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, @NonNull FieldAccessor fieldAccessor,
+                                                       @NonNull String getterCode, @NonNull String name, boolean isPrimitive) {
+        methodBuilder.addCode("\n");
+        if (!isPrimitive) {
+            methodBuilder.beginControlFlow("if (object." + getterCode + " != null) ");
+        }
+        methodBuilder.addStatement("writer.name(\"" + name + "\")");
+        if (!isPrimitive) {
+            methodBuilder.addStatement(
+                    adapterFieldInfo.getAdapterAccessor(element.getValue(), name) + ".write(writer, object." +
+                            getterCode + ")");
+            /*
+             * If the element is annotated with NonNull annotation, throw {@link IOException} if it is null.
+             */
+            if (fieldAccessor.doesRequireNotNull()) {
+                methodBuilder.endControlFlow();
+                methodBuilder.beginControlFlow("else if (object." + getterCode + " == null)");
+                methodBuilder.addStatement("throw new java.io.IOException(\"" + getterCode +
+                        " cannot be null\")");
+            }
+            methodBuilder.endControlFlow();
+        } else {
+            methodBuilder.addStatement("writer.value(object." + getterCode + ")");
+        }
+    }
+
+    private static void specForSerializedNullsEnabled(@NonNull MethodSpec.Builder methodBuilder, @NonNull Map.Entry<FieldAccessor, TypeMirror> element,
+                                                      @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo,
+                                                      @NonNull FieldAccessor fieldAccessor, @NonNull String getterCode, @NonNull String name, boolean isPrimitive) {
+        methodBuilder.addCode("\n");
+        methodBuilder.addStatement("writer.name(\"" + name + "\")");
+        if (!isPrimitive) {
+            methodBuilder.beginControlFlow("if (object." + getterCode + " != null) ");
+        }
+        if (!isPrimitive) {
+            methodBuilder.addStatement(
+                    adapterFieldInfo.getAdapterAccessor(element.getValue(), name) + ".write(writer, object." +
+                            getterCode + ")");
+            /*
+             * If the element is annotated with NonNull annotation, throw {@link IOException} if it is null.
+             */
+            methodBuilder.endControlFlow();
+            methodBuilder.beginControlFlow("else");
+            if (fieldAccessor.doesRequireNotNull()) {
+                //throw exception in case the field is annotated as NonNull
+                methodBuilder.addStatement("throw new java.io.IOException(\"" + getterCode + " cannot be null\")");
+            } else {
+                //write null value to the writer if the field is null
+                methodBuilder.addStatement("writer.nullValue()");
+            }
+            methodBuilder.endControlFlow();
+        } else {
+            methodBuilder.addStatement("writer.value(object." + getterCode + ")");
+        }
+    }
+}

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/WriteSpecGenerator.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/generators/typeadapter/WriteSpecGenerator.java
@@ -1,7 +1,5 @@
 package com.vimeo.stag.processor.generators.typeadapter;
 
-import android.support.annotation.NonNull;
-
 import com.google.gson.stream.JsonWriter;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
@@ -20,8 +18,8 @@ import javax.lang.model.type.TypeMirror;
 public class WriteSpecGenerator {
 
     @NotNull
-    public static MethodSpec getWriteMethodSpec(@NonNull TypeName typeName, @NonNull Map<FieldAccessor, TypeMirror> memberVariables,
-                                                @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, boolean serializeNulls) {
+    public static MethodSpec getWriteMethodSpec(@NotNull TypeName typeName, @NotNull Map<FieldAccessor, TypeMirror> memberVariables,
+                                                @NotNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, boolean serializeNulls) {
         final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("write")
                 .addParameter(JsonWriter.class, "writer")
                 .addParameter(typeName, "object")
@@ -56,9 +54,9 @@ public class WriteSpecGenerator {
         return methodBuilder.build();
     }
 
-    private static void specForSerializedNullsDisabled(@NonNull MethodSpec.Builder methodBuilder, @NonNull Map.Entry<FieldAccessor, TypeMirror> element,
-                                                       @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, @NonNull FieldAccessor fieldAccessor,
-                                                       @NonNull String getterCode, @NonNull String name, boolean isPrimitive) {
+    private static void specForSerializedNullsDisabled(@NotNull MethodSpec.Builder methodBuilder, @NotNull Map.Entry<FieldAccessor, TypeMirror> element,
+                                                       @NotNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo, @NotNull FieldAccessor fieldAccessor,
+                                                       @NotNull String getterCode, @NotNull String name, boolean isPrimitive) {
         methodBuilder.addCode("\n");
         if (!isPrimitive) {
             methodBuilder.beginControlFlow("if (object." + getterCode + " != null) ");
@@ -69,7 +67,7 @@ public class WriteSpecGenerator {
                     adapterFieldInfo.getAdapterAccessor(element.getValue(), name) + ".write(writer, object." +
                             getterCode + ")");
             /*
-             * If the element is annotated with NonNull annotation, throw {@link IOException} if it is null.
+             * If the element is annotated with NotNull annotation, throw {@link IOException} if it is null.
              */
             if (fieldAccessor.doesRequireNotNull()) {
                 methodBuilder.endControlFlow();
@@ -83,9 +81,9 @@ public class WriteSpecGenerator {
         }
     }
 
-    private static void specForSerializedNullsEnabled(@NonNull MethodSpec.Builder methodBuilder, @NonNull Map.Entry<FieldAccessor, TypeMirror> element,
-                                                      @NonNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo,
-                                                      @NonNull FieldAccessor fieldAccessor, @NonNull String getterCode, @NonNull String name, boolean isPrimitive) {
+    private static void specForSerializedNullsEnabled(@NotNull MethodSpec.Builder methodBuilder, @NotNull Map.Entry<FieldAccessor, TypeMirror> element,
+                                                      @NotNull TypeAdapterGenerator.AdapterFieldInfo adapterFieldInfo,
+                                                      @NotNull FieldAccessor fieldAccessor, @NotNull String getterCode, @NotNull String name, boolean isPrimitive) {
         methodBuilder.addCode("\n");
         methodBuilder.addStatement("writer.name(\"" + name + "\")");
         if (!isPrimitive) {
@@ -96,12 +94,12 @@ public class WriteSpecGenerator {
                     adapterFieldInfo.getAdapterAccessor(element.getValue(), name) + ".write(writer, object." +
                             getterCode + ")");
             /*
-             * If the element is annotated with NonNull annotation, throw {@link IOException} if it is null.
+             * If the element is annotated with NotNull annotation, throw {@link IOException} if it is null.
              */
             methodBuilder.endControlFlow();
             methodBuilder.beginControlFlow("else");
             if (fieldAccessor.doesRequireNotNull()) {
-                //throw exception in case the field is annotated as NonNull
+                //throw exception in case the field is annotated as NotNull
                 methodBuilder.addStatement("throw new java.io.IOException(\"" + getterCode + " cannot be null\")");
             } else {
                 //write null value to the writer if the field is null


### PR DESCRIPTION
In GSON, You can configure it to serialize null values by setting serializeNulls. Hence while generating type adapters using Stag, we can have a compiler flag to enable/disable serialising null values. Current implementation of stag generates type-adapters which write null values if the object being serialised is null.

By default, serializeNulls will be set to false (in parity with GSON behaviour)

**Changes:**

1. serializeNulls as a compiler flag to enable/disable serialising null values.
2. Moved Read and Write Spec generators to a different class as the TypeAdapterGenerator was becoming huge in terms of code.

With serializeNull Enabled:

<img width="653" alt="screen shot 2018-09-19 at 11 00 10 am" src="https://user-images.githubusercontent.com/16556984/45732758-66c25f80-bbfb-11e8-8c26-e2f52a727b28.png">

With serializeNull Disabled / Default behaviour:

<img width="632" alt="screen shot 2018-09-19 at 10 59 30 am" src="https://user-images.githubusercontent.com/16556984/45732771-717cf480-bbfb-11e8-8f5b-402fad8f22d2.png">
