### PR TITLE
Release/2.6.0 Preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 android:
   components:
     - tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
     - extra-android-support
     - extra-android-m2repository
 # workaround for Google changing android-27 package and causing a checksum mismatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+Version 2.6.0 *(2018-10-25)*
+----------------------------
+- Improved formatting of generated code.
+- Improved logging by putting all debug logging behind the `stagDebug` flag.
+- Improve integration of library by switching to new nullability annotations library.
+- Wrote unit tests for `KnownTypeAdapters`.
+- Fixed bug where code generation was non deterministic by switching to linked versions of `HashSet` and `HashMap`.
+- Added support for turning on/off serialization of `null` with `stag.serializeNulls` compiler option. Default is off, which is a behavior change from version 2.5.1.
+
 Version 2.5.1 *(2018-01-17)*
 ----------------------------
 - Fixed bug where types with wildcards caused compilation to fail.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ buildscript {
 apply plugin: 'net.ltgt.apt'
 
 dependencies {
-    def stagVersion = '2.5.1'
+    def stagVersion = '2.6.0'
     compile "com.vimeo.stag:stag-library:$stagVersion"
     apt "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }
@@ -45,9 +45,10 @@ dependencies {
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
         aptOptions.processorArgs = [
-                stagAssumeHungarianNotation: "true",
-                stagGeneratedPackageName   : "com.vimeo.sample.stag.generated",
-                stagDebug                  : "true"
+                "stagAssumeHungarianNotation": "true",
+                "stagGeneratedPackageName"   : "com.vimeo.sample.stag.generated",
+                "stagDebug "                 : "true",
+                "stag.serializeNulls"        : "true",
         ]
     }
 }
@@ -58,7 +59,7 @@ gradle.projectsEvaluated {
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-    def stagVersion = '2.5.1'
+    def stagVersion = '2.6.0'
     compile "com.vimeo.stag:stag-library:$stagVersion"
     kapt "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }
@@ -70,6 +71,7 @@ kapt {
         arg("stagDebug", "true")
         arg("stagGeneratedPackageName", "com.vimeo.sample.stag.generated")
         arg("stagAssumeHungarianNotation", "true")
+        arg("stag.serializeNulls", "true")
     }
 }
 ```
@@ -78,7 +80,7 @@ kapt {
 
 ```groovy
 dependencies {
-    def stagVersion = '2.5.1'
+    def stagVersion = '2.6.0'
     compile "com.vimeo.stag:stag-library:$stagVersion"
     annotationProcessor "com.vimeo.stag:stag-library-compiler:$stagVersion"
 }
@@ -91,9 +93,10 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                    stagAssumeHungarianNotation: 'true'
-                    stagGeneratedPackageName   : 'com.vimeo.sample.stag.generated',
-                    stagDebug                  : 'true'
+                    "stagAssumeHungarianNotation": 'true',
+                    "stagGeneratedPackageName"   : 'com.vimeo.sample.stag.generated',
+                    "stagDebug"                  : 'true',
+                    "stag.serializeNulls"        : 'true'
                 ]
             }
         }
@@ -112,6 +115,10 @@ android {
  Stag will look for members named `set[variable_name]` and `get[variable_name]`. If your member variables are named using Hungarian notation,
  then you will need to pass true to this parameter so that for a field named `mField`, Stag will look for `setField` and `getField` instead
  of `setMField` and `getMField`. Default is false.
+ - `stag.serializeNulls`: By default this is set to false. If an object has a null field and you send it to be serialized by Gson, it is optional
+ whether or not that field is serialized into the JSON. If this field is set to `false` null fields will not be serialized, and if set to `true`, 
+ they will be serialized. Prior to stag version 2.6.0, null fields were always serialized to JSON. This should not affect most models. However, if
+ you have a model that has a nullable field that also has a non null default value, then it might be a good idea to turn this option on.
 
 ## Features
 
@@ -249,7 +256,7 @@ class Herd {
  * You parse the list from JSON using
  * Gson.
  */
-MyParsingClass {
+class MyParsingClass {
     private Gson gson = new GsonBuilder()
                                  .registerTypeAdapterFactory(new Stag.Factory())
                                  .create();

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
     ext {
-        kotlinVersion = '1.2.61'
+        kotlinVersion = '1.2.71'
         jacocoVersion = '0.7.9' // See http://www.eclemma.org/jacoco/
         gsonVersion = '2.8.2'
         assertJ = '3.9.1'
 
         // android dependencies
-        targetSdk = 27
+        targetSdk = 28
         minSdk = 14
-        buildTools = "27.0.3"
+        buildTools = "28.0.3"
     }
     repositories {
         google()
@@ -17,7 +17,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
@@ -43,5 +43,5 @@ allprojects {
 
 subprojects {
     group = 'com.vimeo.stag'
-    version = '2.5.1'
+    version = '2.6.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 09 13:12:02 EDT 2018
+#Thu Oct 25 11:29:47 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/integration-test-android/build.gradle
+++ b/integration-test-android/build.gradle
@@ -34,8 +34,8 @@ android {
 
 dependencies {
     implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
 
     implementation project(':stag-library')
     annotationProcessor project(':stag-library-compiler')

--- a/integration-test-java-cross-module/build.gradle
+++ b/integration-test-java-cross-module/build.gradle
@@ -4,10 +4,10 @@ apply plugin: "net.ltgt.apt"
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation 'org.jetbrains:annotations-java5:16.0.2@jar'
-    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:support-annotations:28.0.0'
 
     implementation project(':stag-library')
-    apt project(':stag-library-compiler')
+    annotationProcessor project(':stag-library-compiler')
 
     implementation project(':integration-test-java')
 

--- a/integration-test-java/build.gradle
+++ b/integration-test-java/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
 
     implementation project(':stag-library')
-    apt project(':stag-library-compiler')
+    annotationProcessor project(':stag-library-compiler')
 
     testImplementation 'junit:junit:4.12'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,7 +45,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 
     implementation project(':stag-library')
     annotationProcessor project(':stag-library-compiler')

--- a/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
+++ b/stag-library-compiler/src/main/java/com/vimeo/stag/processor/StagProcessor.java
@@ -72,14 +72,14 @@ import javax.lang.model.type.TypeMirror;
 
 @AutoService(Processor.class)
 @SupportedAnnotationTypes(value = {"com.vimeo.stag.UseStag"})
-@SupportedOptions(value = {StagProcessor.OPTION_PACKAGE_NAME, StagProcessor.OPTION_DEBUG, StagProcessor.OPTION_HUNGARIAN_NOTATION})
+@SupportedOptions(value = {StagProcessor.OPTION_PACKAGE_NAME, StagProcessor.OPTION_DEBUG, StagProcessor.OPTION_HUNGARIAN_NOTATION, StagProcessor.OPTION_SERIALIZE_NULLS})
 @SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class StagProcessor extends AbstractProcessor {
 
     static final String OPTION_DEBUG = "stagDebug";
     static final String OPTION_PACKAGE_NAME = "stagGeneratedPackageName";
     static final String OPTION_HUNGARIAN_NOTATION = "stagAssumeHungarianNotation";
-    static final String OPTION_SERIALIZE_NULLS = "serializeNulls";
+    static final String OPTION_SERIALIZE_NULLS = "stag.serializeNulls";
     private static final String DEFAULT_GENERATED_PACKAGE_NAME = "com.vimeo.stag.generated";
     private boolean mHasBeenProcessed;
 


### PR DESCRIPTION
# Summary
- Updated build tools versions.
- Updated some minor dependencies.
- Added Changelog for 2.6.0.
- Changed name of `serializeNulls` to `stag.serializeNulls`.
- Updated README for 2.6.0.